### PR TITLE
chore: add PR template and rule enforcing PR-based workflow

### DIFF
--- a/.cursor/rules/pr-policy.mdc
+++ b/.cursor/rules/pr-policy.mdc
@@ -1,0 +1,12 @@
+---
+alwaysApply: true
+description: Require feature work to be done via pull requests with CI passing and session notes updated.
+---
+
+# Pull Request policy
+
+- All substantive changes (features, refactors, deps, config) should be done in branches and merged via PRs.
+- PRs must pass CI (RuboCop, Brakeman) and follow the PR template.
+- Update [SESSION_NOTES.md](mdc:SESSION_NOTES.md) for notable changes.
+- Prefer small, focused PRs.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- What does this change do? Why?
+
+## Testing
+
+- How did you test this? Include commands or screenshots.
+
+## Checklist
+
+- [ ] CI green (RuboCop + Brakeman)
+- [ ] No secrets committed
+- [ ] Session notes updated if applicable
+
+


### PR DESCRIPTION
- Add `.github/pull_request_template.md` to standardize submissions
- Add always-applied rule `.cursor/rules/pr-policy.mdc` to prefer PRs for substantive changes

This aligns with the new process to land feature work via PRs with CI passing and notes updated.