### PR TITLE
fix(good_job): enable cookies/session/flash for GoodJob UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ bin/rails s
 ## Market data subscriber
 - Enqueue ticker subscription (GoodJob):
 ```bash
-bin/rake market_data:subscribe[BTC-USD-PERP]
-bin/rake market_data:subscribe[BTC-USD-PERP,ETH-USD-PERP]
+bin/rake "market_data:subscribe[BTC-USD-PERP]"
+bin/rake "market_data:subscribe[BTC-USD-PERP,ETH-USD-PERP]"
+# or use env var (no quoting needed):
+PRODUCT_IDS=BTC-USD-PERP bin/rake market_data:subscribe
 ```
 
 Logs will show ticker messages at debug level.

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,10 @@ module CoinbaseFuturesBot
 
     # Use GoodJob for Active Job processing
     config.active_job.queue_adapter = :good_job
+
+    # Enable cookies, session, and flash for GoodJob UI in API-only app
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, key: "_coinbase_futures_bot_session"
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.config.session_store :cookie_store,
+  key: "_coinbase_futures_bot_session",
+  same_site: :lax,
+  secure: Rails.env.production?
+
+


### PR DESCRIPTION
- Add cookies, session, and flash middleware to API-only app so GoodJob UI can access `request.flash`
- Add cookie session store initializer with sane defaults

After merge, restart server and visit `/good_job` again.