### PR TITLE
Debug market data subscription ticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ bin/rake market_data:subscribe[BTC-USD-PERP]
 bin/rake market_data:subscribe[BTC-USD-PERP,ETH-USD-PERP]
 ```
 
+- Run inline (foreground) to print ticks to STDOUT:
+```bash
+INLINE=1 bin/rake "market_data:subscribe[BTC-USD-PERP]"
+```
+
 Logs will show ticker messages at debug level.
 
 ## Admin UI

--- a/app/services/market_data/coinbase_futures_subscriber.rb
+++ b/app/services/market_data/coinbase_futures_subscriber.rb
@@ -17,9 +17,10 @@ module MarketData
       @ws.on(:open) { subscribe }
       @ws.on(:message) { |msg| handle_message(msg) }
       @ws.on(:error) { |e| @logger.error("[MD] error: #{e}") }
-      @ws.on(:close) { @logger.info("[MD] closed") }
+      @ws.on(:close) { @logger.info("[MD] closed"); @ws = nil }
 
-      sleep 0.1 while @ws&.open?
+      # Keep the job alive until the websocket closes
+      sleep 0.1 while @ws
     end
 
     private

--- a/lib/tasks/market_data.rake
+++ b/lib/tasks/market_data.rake
@@ -4,7 +4,15 @@ namespace :market_data do
   desc "Subscribe to Coinbase futures ticker (GoodJob async)"
   task :subscribe, [ :products ] => :environment do |_t, args|
     products = (args[:products] || ENV["PRODUCT_IDS"] || "BTC-USD-PERP").split(",")
-    MarketDataSubscribeJob.perform_later(products)
-    puts "Enqueued MarketDataSubscribeJob for: #{products.join(",")}"
+
+    if ENV["INLINE"].to_s == "1"
+      puts "Running inline subscription for: #{products.join(",")}"
+      stdout_logger = Logger.new($stdout)
+      stdout_logger.level = Logger::DEBUG
+      MarketData::CoinbaseFuturesSubscriber.new(product_ids: products, logger: stdout_logger).start
+    else
+      MarketDataSubscribeJob.perform_later(products)
+      puts "Enqueued MarketDataSubscribeJob for: #{products.join(",")}"
+    end
   end
 end

--- a/lib/tasks/market_data.rake
+++ b/lib/tasks/market_data.rake
@@ -13,6 +13,5 @@ namespace :market_data do
     else
       MarketDataSubscribeJob.perform_later(products)
       puts "Enqueued MarketDataSubscribeJob for: #{products.join(",")}"
-    end
   end
 end

--- a/lib/tasks/market_data.rake
+++ b/lib/tasks/market_data.rake
@@ -12,6 +12,7 @@ namespace :market_data do
       MarketData::CoinbaseFuturesSubscriber.new(product_ids: products, logger: stdout_logger).start
     else
       MarketDataSubscribeJob.perform_later(products)
-      puts "Enqueued MarketDataSubscribeJob for: #{products.join(",")}"
+      puts "Enqueued MarketDataSubscribeJob for: #{products.join(",") }"
+    end
   end
 end


### PR DESCRIPTION
## Summary

- This change addresses an issue where users running `bin/rake market_data:subscribe` would not see market data ticks directly in their terminal.
- The `market_data:subscribe` rake task now supports an `INLINE=1` option, allowing the subscriber to run synchronously in the foreground and print ticks to STDOUT.
- The `MarketData::CoinbaseFuturesSubscriber` was also updated to ensure the websocket connection is maintained until properly closed, preventing premature exits.
- The `README.md` has been updated with instructions for using the new `INLINE` mode.

## Testing

- Tested by running `INLINE=1 bin/rake "market_data:subscribe[BTC-USD-PERP]"` and observing ticks printed to STDOUT.

## Checklist

- [ ] CI green (RuboCop + Brakeman)
- [ ] No secrets committed
- [ ] Session notes updated if applicable

---
<a href="https://cursor.com/background-agent?bcId=bc-dbf5340f-9689-4c01-b5ba-a321d3defc7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbf5340f-9689-4c01-b5ba-a321d3defc7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

