### PR TITLE
Verify and document candle data collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,13 @@ bundle exec good_job start
 ## Contributing workflow
 - All substantive changes go through PRs. CI (RuboCop, Brakeman) must pass.
 - Update `SESSION_NOTES.md` for notable changes.
+
+## Candle data collection
+- Fetch and store OHLCV candles (Coinbase spot):
+  - `bin/rake market_data:backfill_candles[7]` enqueues `FetchCandlesJob` (default 7 days).
+  - `bin/rake market_data:backfill_1h_candles[30]` writes `1h` candles for last 30 days.
+  - `bin/rake market_data:backfill_30m_candles[7]` writes `15m` candles for last 7 days.
+  - `bin/rake market_data:test_1h_candles[1]` quick test.
+  - `bin/rake market_data:test_granularities` prints supported granularities.
+- Scheduled via GoodJob cron at minute 5 each hour by default. Override with `CANDLES_CRON`.
+- See `docs/candles.md` for full details (schema, env vars, chunked fetching, troubleshooting).

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -171,4 +171,13 @@
   - Create GoodJob initializer for concurrency/queues
   - `bin/rails db:migrate`
 
+#### 2025-08-12
+- Context: Ensure candle data collection is working and documented.
+- Changes:
+  - Fixed `FetchCandlesJob` start_time selection to use the later of last-candle+1h and backfill window.
+  - Added `docs/candles.md` detailing schema, fetching paths, cron, env, and troubleshooting.
+  - Updated `README.md` with a Candle data collection section linking to the docs.
+- Next steps:
+  - Run test suite locally (requires Ruby/Bundler) and verify GoodJob cron executes `FetchCandlesJob`.
+
 

--- a/app/jobs/fetch_candles_job.rb
+++ b/app/jobs/fetch_candles_job.rb
@@ -13,7 +13,8 @@ class FetchCandlesJob < ApplicationJob
     return unless btc_pair
 
     begin
-      start_time = [ last_candle_time(btc_pair.product_id)&.+(1.hour), backfill_days.to_i.days.ago ].compact.min
+      # Choose the later of (last known + 1h) and (backfill_days ago)
+      start_time = [ last_candle_time(btc_pair.product_id)&.+(1.hour), backfill_days.to_i.days.ago ].compact.max
 
       # Use chunked fetching for large date ranges to avoid API limits
       if backfill_days.to_i > 30

--- a/docs/candles.md
+++ b/docs/candles.md
@@ -1,0 +1,63 @@
+# Candle Data Collection
+
+This service collects and stores OHLCV candles primarily for Coinbase spot markets (e.g., `BTC-USD`). Candles are stored in the `candles` table and used by strategies and paper trading.
+
+## What is collected
+- **Timeframes**: `1h` and `15m`
+  - `1h` candles come directly from the API with granularity 3600s.
+  - `15m` candles are fetched with granularity 900s. The code path is named `upsert_30m_candles` for historical reasons but stores as `15m`.
+- **Fields**: `symbol`, `timeframe`, `timestamp`, `open`, `high`, `low`, `close`, `volume`.
+- **Uniqueness**: Unique on `(symbol, timeframe, timestamp)` to prevent duplicates.
+
+## Storage schema
+```
+symbol: string (e.g., BTC-USD)
+timeframe: string (15m, 1h, 6h, 1d)
+timestamp: datetime UTC
+open/high/low/close: decimal(20,10)
+volume: decimal(30,10)
+```
+
+## How candles are fetched
+- Implemented in `MarketData::CoinbaseRest`:
+  - `fetch_candles(product_id:, start_iso8601:, end_iso8601:, granularity:)` returns arrays of `[time, low, high, open, close, volume]`.
+  - `upsert_1h_candles(product_id:, start_time:, end_time:)` writes `1h` candles.
+  - `upsert_1h_candles_chunked(...)` collects large ranges in chunks (avoids rate limits).
+  - `upsert_30m_candles(product_id:, ...)` writes `15m` candles using 900s granularity.
+  - `upsert_30m_candles_chunked(...)` chunked version for large ranges.
+
+- Scheduled fetching is handled by `FetchCandlesJob` (GoodJob cron):
+  - Calculates a `start_time` as the later of:
+    - last stored candle timestamp + 1 hour
+    - `backfill_days` ago (defaults to 7)
+  - Upserts `1h` candles for `BTC-USD`.
+
+## Running it
+- One-off backfill via Rake:
+  - `bin/rake market_data:backfill_candles[7]` enqueues `FetchCandlesJob` with 7 days backfill.
+  - `bin/rake market_data:backfill_1h_candles[30]` directly fetches and stores `1h` candles for the last 30 days.
+  - `bin/rake market_data:backfill_30m_candles[7]` fetches and stores `15m` candles for the last 7 days.
+  - `bin/rake market_data:test_1h_candles[1]` quick test for `1h` fetching.
+  - `bin/rake market_data:test_granularities` prints supported granularities.
+
+- Scheduled via GoodJob cron (see `config/initializers/good_job.rb`):
+  - `FetchCandlesJob` runs at minute 5 of every hour by default.
+  - Configure with `CANDLES_CRON` env var (cron syntax), e.g.: `CANDLES_CRON="*/30 * * * *"`.
+
+## Environment variables
+- `COINBASE_REST_URL` (optional): Override API base URL; default `https://api.exchange.coinbase.com`.
+- `COINBASE_API_KEY`, `COINBASE_API_SECRET` (optional): If set, authenticated calls may have better limits.
+- `CANDLES_CRON` (optional): GoodJob cron schedule for `FetchCandlesJob`.
+
+## Notes and tips
+- The API may return data newest-first. The importer sorts oldest→newest before upserting.
+- Large backfills use chunked fetching to reduce rate-limit errors.
+- If you only want to catch up to the latest candle without re-fetching history, prefer `market_data:backfill_candles[<small_number>]` or rely on the hourly cron.
+- `Candle` model scopes:
+  - `Candle.for_symbol("BTC-USD")`
+  - `Candle.hourly` and `Candle.fifteen_minute`
+
+## Troubleshooting
+- If you see rate-limit errors, lower `chunk_days` (see `upsert_1h_candles_chunked`) or add API credentials.
+- Ensure `TradingPair` exists for `BTC-USD`: run `bin/rake market_data:upsert_futures_products` first if needed.
+- Check GoodJob dashboard to confirm `FetchCandlesJob` runs on schedule.


### PR DESCRIPTION
## Summary

- **What does this change do?**
    - Fixes `FetchCandlesJob` to correctly calculate the `start_time` for fetching candles, using the later of the last known candle time + 1 hour or the backfill window.
    - Adds comprehensive documentation for candle data collection in `docs/candles.md`, detailing schema, fetching methods, rake tasks, cron scheduling, and troubleshooting.
    - Updates `README.md` with a new "Candle data collection" section, providing a high-level overview and linking to the detailed documentation.
    - Updates `SESSION_NOTES.md` to reflect these changes.
- **Why?**
    - To ensure all candle data collection functionality is working correctly and is well-documented as per the user's request.
    - The `FetchCandlesJob` fix prevents unnecessary refetching of historical data, improving correctness and performance.
    - The new documentation provides clear guidance for operators on backfills, cron, and troubleshooting.

## Testing

- **How did you test this?**
    - Code changes were reviewed for correctness.
    - Local testing was not performed by the AI due to environment limitations.
    - To test locally, ensure Ruby 3.2.x and Bundler are installed, then:
        - `bundle install`
        - `RAILS_ENV=test bin/rails db:prepare`
        - `bundle exec rake test`
    - Manual verification of candle fetching can be done using:
        - `bin/rake market_data:backfill_candles[1]`
        - `bin/rake market_data:backfill_1h_candles[1]`
        - `bin/rake market_data:backfill_30m_candles[1]` (for 15m candles)

## Checklist

- [ ] CI green (RuboCop + Brakeman)
- [ ] No secrets committed
- [x] Session notes updated if applicable

---
<a href="https://cursor.com/background-agent?bcId=bc-7d49064c-2d92-4cf7-8e1b-54ed321c150b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d49064c-2d92-4cf7-8e1b-54ed321c150b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

