### PR TITLE
Investigate failing test cases

### DIFF
--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -25,6 +25,19 @@
 - Configure branch protection required checks after CI green
 
 ### Session log
+#### 2025-08-13 12:05 UTC
+- Context: Fix failing specs around positions close action and error redirect while local Ruby is unavailable.
+- Changes:
+  - Accept `size` (preferred) or `close_size` in `PositionsController#close` to satisfy specs expecting `size`.
+  - Correct `new_position_path` redirect to pass `product_id` as a named param.
+- Commands run:
+  - `git add -A && git commit -m "fix(positions): accept size param for close; fix new_position_path redirect param passing"`
+- Files touched:
+  - `app/controllers/positions_controller.rb`, `SESSION_NOTES.md`
+- Next steps:
+  - Run `bundle exec rspec` locally/CI to verify green.
+  - If any controller/request specs still fail, adjust redirects and params accordingly.
+
 #### 2025-08-12 18:30 UTC
 - Context: candles (1h/15m) stored; need entry decisions using both timeframes.
 - Changes:

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -41,7 +41,7 @@ class PositionsController < ActionController::Base
       )
       redirect_to positions_path(notice: "Position opened: #{result["order_id"] || result["message"] || result["success"]}")
     rescue => e
-      redirect_to new_position_path(product_id, notice: "Error: #{e.message}")
+      redirect_to new_position_path(product_id: product_id, notice: "Error: #{e.message}")
     end
   end
 
@@ -75,7 +75,7 @@ class PositionsController < ActionController::Base
 
   def close
     product_id = params[:product_id]
-    size_to_close = params[:close_size].presence
+    size_to_close = params[:size].presence || params[:close_size].presence
 
     Rails.logger.info("CLOSE ACTION CALLED: product_id=#{product_id}, size=#{size_to_close}")
 

--- a/app/services/trading/coinbase_positions.rb
+++ b/app/services/trading/coinbase_positions.rb
@@ -115,11 +115,12 @@ module Trading
       # LONG position: SELL contracts to close (opposite of your position)
       # SHORT position: BUY contracts to close (opposite of your position)
       # Note: infer_position returns :long/:short, we need to convert to :buy/:sell
-      close_side = case pos_side
-      when :long then :sell
-      when :short then :buy
-      when :buy then :sell
-      when :sell then :buy
+      normalized_pos_side = pos_side.to_s.downcase
+      close_side = case normalized_pos_side
+      when "long" then :sell
+      when "short" then :buy
+      when "buy" then :sell
+      when "sell" then :buy
       else :sell  # Default fallback
       end
 


### PR DESCRIPTION
## Summary

-   **What does this change do?** This PR addresses failing tests by:
    1.  Modifying `PositionsController#close` to accept both `size` and `close_size` parameters for closing positions, preferring `size`.
    2.  Correcting the parameter passing for `new_position_path` redirect.
    3.  Normalizing the `pos_side` to a string in `Trading::CoinbasePositions#close_position` to ensure correct mapping of position side to close order side (e.g., `SHORT` position correctly maps to a `BUY` close order).
-   **Why?** These changes align the application logic with test expectations and fix a specific failure where a `SHORT` position was incorrectly attempting to close with a `SELL` order instead of a `BUY` order.

## Testing

-   **How did you test this?**
    -   Analyzed failing RSpec output provided by the user for `Trading::CoinbasePositions position closing builds correct order body for SHORT position close (BUY order)`.
    -   Inspected `spec/services/coinbase_positions_spec.rb` and `app/services/trading/coinbase_positions.rb` to identify the mismatch in `pos_side` handling.
    -   The user was instructed to run `bundle exec rspec` locally to verify the fixes.

## Checklist

-   [ ] CI green (RuboCop + Brakeman)
-   [ ] No secrets committed
-   [x] Session notes updated if applicable

---
<a href="https://cursor.com/background-agent?bcId=bc-82564a14-0656-45b8-846c-d445565f63d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82564a14-0656-45b8-846c-d445565f63d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

