### PR TITLE
Fix nil comparison in position management job

### DIFF
--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -26,6 +26,28 @@
 
 ### Session log
 
+#### 2025-08-28 18:05 UTC
+- Context: **FUT-30 COMPLETED** - Fixed NoMethodError in DayTradingPositionManagementJob where nil values caused comparison errors
+- Changes:
+  - **MAJOR**: Fixed critical nil value error in `DayTradingPositionManagementJob#perform` line 63
+  - **MAJOR**: Corrected key mismatch between job (`summary[:closed_today]`) and position manager (`summary[:closed_today_count]`)
+  - Added proper nil value handling with safe defaults (`|| 0`) for all summary fields
+  - Updated variable extraction pattern to prevent nil comparisons: `closed_today_count = summary[:closed_today_count] || 0`
+  - Added explicit nil values for missing fields (`daily_pnl`, `win_rate`) in SlackNotificationService calls
+  - Enhanced error prevention across all summary field access points
+- Commands run:
+  - `bundle install` - Installed gems to enable testing
+  - `bundle exec rspec spec/jobs/day_trading_position_management_job_spec.rb` - All 10 tests passing
+  - `bin/standardrb --fix` - Applied code formatting (no issues)
+  - `bundle exec rails runner` - Verified job instantiation works correctly
+- Files touched:
+  - `app/jobs/day_trading_position_management_job.rb` - Fixed nil handling and key mismatches
+- Migrations:
+  - None required
+- Next steps:
+  - **Issue fully resolved**: Job now handles nil values safely and uses correct summary keys
+  - Consider adding `daily_pnl` and `win_rate` to position manager summary for future enhancements
+
 #### 2025-08-28 17:50 UTC
 - Context: **FUT-29 COMPLETED** - Fully resolved CryptoPanic API 404 error with v2 API migration
 - Changes:

--- a/app/jobs/day_trading_position_management_job.rb
+++ b/app/jobs/day_trading_position_management_job.rb
@@ -60,28 +60,32 @@ class DayTradingPositionManagementJob < ApplicationJob
     @logger.info("Day trading position summary: #{summary}")
 
     # Send periodic PnL update if significant activity
-    if summary[:total_pnl] && (summary[:closed_today] > 0 || summary[:open_count] > 5)
+    closed_today_count = summary[:closed_today_count] || 0
+    open_count = summary[:open_count] || 0
+
+    if summary[:total_pnl] && (closed_today_count > 0 || open_count > 5)
       SlackNotificationService.pnl_update({
         total_pnl: summary[:total_pnl],
-        daily_pnl: summary[:daily_pnl],
-        open_positions: summary[:open_count],
-        closed_today: summary[:closed_today],
-        win_rate: summary[:win_rate]
+        daily_pnl: nil, # daily_pnl not available in position summary
+        open_positions: open_count,
+        closed_today: closed_today_count,
+        win_rate: nil # win_rate not available in position summary
       })
     end
 
     # Log any remaining open positions
-    if summary[:open_count] > 0
-      @logger.info("Remaining open day trading positions: #{summary[:open_count]}")
-      @logger.info("Positions needing closure: #{summary[:positions_needing_closure]}")
-      @logger.info("Positions approaching closure: #{summary[:positions_approaching_closure]}")
+    if open_count > 0
+      @logger.info("Remaining open day trading positions: #{open_count}")
+      @logger.info("Positions needing closure: #{summary[:positions_needing_closure] || 0}")
+      @logger.info("Positions approaching closure: #{summary[:positions_approaching_closure] || 0}")
 
       # Alert if too many positions approaching closure
-      if summary[:positions_approaching_closure] > 3
+      approaching_closure_count = summary[:positions_approaching_closure] || 0
+      if approaching_closure_count > 3
         SlackNotificationService.alert(
           "warning",
           "Multiple Positions Approaching Closure",
-          "#{summary[:positions_approaching_closure]} positions are approaching the 24-hour day trading limit."
+          "#{approaching_closure_count} positions are approaching the 24-hour day trading limit."
         )
       end
     end


### PR DESCRIPTION
Fix `NoMethodError` in `DayTradingPositionManagementJob` by correcting key names and adding safe nil handling for position summary data.

The error occurred because `summary[:closed_today]` was `nil` (it should be `summary[:closed_today_count]`) and other fields like `daily_pnl` and `win_rate` were being accessed but do not exist in the `get_position_summary` method's return value. This PR ensures all accessed summary fields are safely handled with defaults (`|| 0`) or explicit `nil` assignments to prevent runtime errors.

---
Linear Issue: [FUT-30](https://linear.app/ericdahl/issue/FUT-30/nomethoderror-undefined-method-for-nilnilclass-nomethoderror)

<a href="https://cursor.com/background-agent?bcId=bc-509c4918-342e-4ff2-9471-8b86c476b17a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-509c4918-342e-4ff2-9471-8b86c476b17a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

