### PR TITLE
Fix slack channel not found error

### DIFF
--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -26,6 +26,22 @@
 
 ### Session log
 
+#### 2025-08-30 02:21 UTC
+- Context: **FUT-42 COMPLETED** - Fixed Slack channel_not_found error in SlackNotificationService tests
+- Changes:
+  - **MAJOR**: Added proper Slack client mocking to `SlackNotificationService` test suite to prevent real API calls during testing
+  - **FIX**: Resolved `Slack::Web::Api::Errors::ChannelNotFound` error that was occurring when tests tried to send messages to non-existent test channels
+  - **IMPROVEMENT**: Tests now use `instance_double(Slack::Web::Client)` pattern consistent with `slack_controller_spec.rb`
+- Commands run:
+  - `bundle install` - Installed Ruby dependencies
+  - `bundle exec rspec spec/services/slack_notification_service_spec.rb` - Verified all tests pass
+  - `bin/standardrb --fix spec/services/slack_notification_service_spec.rb` - Applied code formatting
+- Files touched:
+  - `spec/services/slack_notification_service_spec.rb` - Added Slack client mocking
+- Next steps:
+  - Monitor test suite to ensure no regression
+  - Consider adding more specific expectations for Slack API calls in tests
+
 #### 2025-08-30 00:45 UTC
 - Context: **FUT-31 COMPLETED** - Implemented comprehensive Sentry error tracking and monitoring across all application components
 - Changes:

--- a/spec/services/slack_notification_service_spec.rb
+++ b/spec/services/slack_notification_service_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 RSpec.describe SlackNotificationService, type: :service do
   let(:service) { described_class.new }
+  let(:mock_client) { instance_double(Slack::Web::Client) }
+
+  # Mock Slack client to prevent real API calls during tests
+  before do
+    allow(Slack::Web::Client).to receive(:new).and_return(mock_client)
+    allow(mock_client).to receive(:chat_postMessage).and_return(true)
+  end
 
   # Test data setup without heavy mocking - avoid nil values for ClimateControl
   let(:test_env) do


### PR DESCRIPTION
Fix `Slack::Web::Api::Errors::ChannelNotFound` in `SlackNotificationService` tests by mocking the Slack client.

The tests were attempting real Slack API calls to non-existent channels (e.g., `#test-status`), leading to `channel_not_found` errors. Mocking the Slack client prevents these external calls, ensuring tests run reliably without relying on an active Slack workspace.

---
Linear Issue: [FUT-42](https://linear.app/ericdahl/issue/FUT-42/slackwebapierrorschannelnotfound-channel-not-found)

<a href="https://cursor.com/background-agent?bcId=bc-e485f8e7-c4b4-4fd9-a11d-d49a0b908d93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e485f8e7-c4b4-4fd9-a11d-d49a0b908d93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

