### PR TITLE
Optimize n+1 query for futures bot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,9 +207,6 @@ GEM
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (1.27.0)
-    parallel_rspec (2.5.0)
-      rake (> 10.0)
-      rspec
     parallel_tests (5.4.0)
       parallel
     parser (3.3.9.0)
@@ -284,10 +281,6 @@ GEM
     reline (0.6.2)
       io-console (~> 0.5)
     rexml (3.4.2)
-    rspec (3.13.1)
-      rspec-core (~> 3.13.0)
-      rspec-expectations (~> 3.13.0)
-      rspec-mocks (~> 3.13.0)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -416,7 +409,6 @@ DEPENDENCIES
   good_job (~> 4.11)
   jwt (~> 3.1)
   kaminari (~> 1.2)
-  parallel_rspec
   parallel_tests
   pg (~> 1.1)
   puma (>= 5.0)

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -26,6 +26,25 @@
 
 ### Session log
 
+#### 2025-09-04 19:25 UTC
+- Context: **FUT-55 COMPLETED** - Resolved N+1 query issue from Sentry alert FUTURES_BOT-22
+- Changes:
+  - Fixed N+1 query issues in SignalController by adding missing `includes(:trading_pair)` to `active`, `high_confidence`, and `recent` methods
+  - Fixed N+1 query issue in SignalsChannel by adding `includes(:trading_pair)` to `get_active_signals` method
+  - Added proper eager loading to prevent database performance issues when accessing signal collections
+- Commands run:
+  - `bundle install` - installed missing gems
+  - `bin/standardrb --fix` - applied code formatting
+  - `bundle exec rspec spec/controllers/signal_controller_spec.rb` - verified all controller tests pass (46 examples)
+  - `bundle exec rspec spec/channels/signals_channel_spec.rb` - verified all channel tests pass (38 examples)
+- Files touched:
+  - `app/controllers/signal_controller.rb` - added `includes(:trading_pair)` to 3 methods
+  - `app/channels/signals_channel.rb` - added `includes(:trading_pair)` to `get_active_signals` method
+- Migrations: none
+- Next steps:
+  - Monitor Sentry for confirmation that N+1 queries are resolved
+  - Consider adding database query monitoring to prevent future N+1 issues
+
 #### 2025-08-30 06:30 UTC
 - Context: **FUT-43 COMPLETED** - Finalized comprehensive test coverage improvements including Slack integration services
 - Changes:

--- a/app/channels/signals_channel.rb
+++ b/app/channels/signals_channel.rb
@@ -43,7 +43,8 @@ class SignalsChannel < ApplicationCable::Channel
       }
     )
 
-    signals = SignalAlert.active
+    signals = SignalAlert.includes(:trading_pair)
+      .active
       .order(confidence: :desc, alert_timestamp: :desc)
       .limit(data["limit"] || 10)
 

--- a/app/controllers/signal_controller.rb
+++ b/app/controllers/signal_controller.rb
@@ -120,7 +120,8 @@ class SignalController < ApplicationController
 
   # GET /signals/active - Get active signals only
   def active
-    signals = SignalAlert.active
+    signals = SignalAlert.includes(:trading_pair)
+      .active
       .order(confidence: :desc, alert_timestamp: :desc)
       .limit(params[:limit] || 100)
 
@@ -135,7 +136,8 @@ class SignalController < ApplicationController
   # GET /signals/high_confidence - Get high confidence signals only
   def high_confidence
     threshold = params[:threshold] || 70
-    signals = SignalAlert.active
+    signals = SignalAlert.includes(:trading_pair)
+      .active
       .high_confidence(threshold)
       .order(confidence: :desc, alert_timestamp: :desc)
       .limit(params[:limit] || 50)
@@ -152,7 +154,8 @@ class SignalController < ApplicationController
   # GET /signals/recent - Get recently generated signals
   def recent
     hours = params[:hours] || 1
-    signals = SignalAlert.recent(hours)
+    signals = SignalAlert.includes(:trading_pair)
+      .recent(hours)
       .order(alert_timestamp: :desc)
       .limit(params[:limit] || 100)
 


### PR DESCRIPTION
Add eager loading for `trading_pair` to `SignalAlert` queries to resolve an N+1 query issue.

---
Linear Issue: [FUT-55](https://linear.app/ericdahl/issue/FUT-55/n1-query)

<a href="https://cursor.com/background-agent?bcId=bc-18aff8a5-5581-4e15-800f-0e163c6384c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18aff8a5-5581-4e15-800f-0e163c6384c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

