### PR TITLE
Fix CI workflow coverage badge issues and remove Codecov dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Coinbase Futures Bot
 
 [![CI Status](https://github.com/Skeyelab/coinbase_futures_bot/workflows/CI/badge.svg)](https://github.com/Skeyelab/coinbase_futures_bot/actions)
-[![codecov](https://codecov.io/gh/Skeyelab/coinbase_futures_bot/branch/main/graph/badge.svg)](https://codecov.io/gh/Skeyelab/coinbase_futures_bot)
 
 An automated cryptocurrency futures trading bot built with Rails 8.0, featuring real-time market data ingestion, multi-timeframe signal generation, sentiment analysis, and risk management.
 
@@ -34,9 +33,9 @@ This project maintains a comprehensive test suite with **141 test examples** cov
 
 ### Coverage Reports
 
-- **Online**: [Codecov Dashboard](https://codecov.io/gh/Skeyelab/coinbase_futures_bot)
-- **Local**: Generated automatically when running tests with coverage
+- **Local**: Generated automatically when running tests with SimpleCov
 - **HTML Report**: View detailed coverage at `coverage/index.html`
+- **CI Coverage**: Coverage data is generated in CI and available as artifacts
 
 ### Running Tests with Coverage
 
@@ -78,15 +77,14 @@ The test suite focuses on the most critical components:
 - **Market Data Integration**: WebSocket subscriber testing with VCR-recorded API responses
 - **Risk Management**: Position sizing, stop losses, and trade execution validation
 
-### Codecov Setup
+### Coverage in CI
 
-To enable Codecov uploads in CI:
+Coverage data is automatically generated during CI runs and available as downloadable artifacts. The CI workflow:
 
-1. Sign up at [codecov.io](https://codecov.io)
-2. Add your repository
-3. Get your repository token
-4. Add `CODECOV_TOKEN` to GitHub repository secrets
-5. CI will automatically upload coverage reports
+1. Runs the full test suite with SimpleCov enabled
+2. Generates coverage reports and HTML output
+3. Uploads coverage artifacts for download
+4. Displays coverage percentage in the workflow logs
 
 ## Prerequisites
 - Ruby 3.2.2 (RVM recommended; repo uses `.ruby-version`)


### PR DESCRIPTION
## Summary

This PR fixes multiple CI workflow issues related to coverage badge generation and removes unnecessary Codecov dependencies.

## Issues Fixed

### 1. Git Identity Configuration
- **Problem**: Coverage badge commits failed with "Author identity unknown" error
- **Fix**: Added Git user configuration before coverage badge generation

### 2. Detached HEAD State
- **Problem**: CI was in detached HEAD state when trying to push commits
- **Fix**: Added branch checkout step to switch to proper branch before pushing

### 3. Missing Upstream Tracking
- **Problem**: Branch had no upstream tracking when trying to push
- **Fix**: Used `git push --set-upstream origin <branch>` to establish tracking

### 4. Empty Branch Name Variable
- **Problem**: Branch name variable was empty between CI steps
- **Fix**: Exported branch name to environment variables for cross-step access

### 5. Repository Write Permissions
- **Problem**: GitHub Actions token lacks write permissions for repository pushes
- **Fix**: Simplified workflow to generate badge URL without automatic commits

### 6. Codecov Badge Issues
- **Problem**: README showed "unknown" Codecov badge (we use SimpleCov, not Codecov)
- **Fix**: Removed Codecov badge and updated documentation to reflect SimpleCov usage

## Changes Made

### CI Workflow (`.github/workflows/ci.yml`)
- Removed Codecov upload step (not needed)
- Simplified coverage badge job to generate badge URL without Git operations
- Removed complex Git checkout, commit, and push functionality
- Kept coverage artifact generation and badge URL output

### Documentation (`README.md`)
- Removed Codecov badge that showed "unknown"
- Updated coverage documentation to reflect SimpleCov usage
- Removed Codecov setup instructions
- Added explanation of CI coverage artifacts

## Testing

All CI workflow runs now complete successfully:
- ✅ StandardRB (lint) - Passes
- ✅ Brakeman (security) - Passes  
- ✅ Rails tests with coverage - Passes
- ✅ Generate Coverage Badge - Passes (generates badge URL for manual use)

## Coverage Badge Usage

The CI now outputs a coverage badge URL that can be manually added to README.md:
```
📊 Coverage Badge URL: https://img.shields.io/badge/coverage-54%25-yellow?style=flat-square
💡 To update your README.md with this badge, run:
   echo '![coverage](https://img.shields.io/badge/coverage-54%25-yellow?style=flat-square)' >> README.md
```

## Impact

- **Simplified CI workflow** - No more complex Git operations that can fail
- **Reliable coverage reporting** - Coverage data available as CI artifacts
- **Accurate documentation** - README matches actual tooling (SimpleCov vs Codecov)
- **No external dependencies** - Removed unnecessary Codecov integration

## Workflow Runs Fixed

- Run #410: Fixed Git identity configuration
- Run #411: Fixed detached HEAD state  
- Run #413: Fixed upstream tracking
- Run #414: Fixed empty branch name variable
- Run #418: Fixed repository permissions (simplified approach)

All subsequent runs should now complete successfully without coverage badge errors.