### PR TITLE
docs: add agent skills config, domain glossary, and ADR scaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,17 @@ _Add a brief overview of your project architecture_
 ## Conventions & Patterns
 
 _Add your project-specific conventions here_
+
+## Agent skills
+
+### Issue tracker
+
+Issues tracked in GitHub Issues (`gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,48 @@
+# Domain Context
+
+## Glossary
+
+### Basis
+The price spread between a futures Contract and the underlying spot price. Checked as a pre-entry gate — if basis is unfavorable, the bot skips entry. Threshold is a parameter of the Risk Profile. Not tracked per-Position after entry.
+
+### Confidence
+A 0–100 score on a Signal representing combined certainty. Starts as a technical score (EMA alignment across timeframes, pattern clarity), then adjusted up or down by Sentiment. The Risk Profile defines a minimum threshold — Signals below it do not trigger entry.
+
+### Contract
+A specific tradeable futures instrument on Coinbase, identified by product ID (e.g. `BIT-29AUG25-CDE` for BTC, `NOL-19JUN26-CDE` for crude oil). Covers both crypto and commodity underlyings. Carries an expiry date; the bot manages rollover before expiration. Maps to the `TradingPair` model (legacy name — industry term is Contract).
+
+### Day Trade
+A Position tagged at entry as intraday — must be closed within 24 hours. The bot auto-closes these via `EndOfDayPositionClosureJob` to maintain compliance. A per-Position property; day trades and swing trades can coexist.
+
+### Order
+An instruction sent to Coinbase to buy or sell a Contract. First-class domain concept — stored and tied to the Position it opens or closes. Enables slippage auditing (actual fill price vs Signal target), execution reconstruction after outages, and full trade lifecycle traceability. Currently not modelled in the code; the `Position` model tracks entry/exit prices but not the underlying exchange orders.
+
+### Paper Trading
+A whole-bot simulation mode where Signals are evaluated and Positions tracked but no real orders are placed on Coinbase. Used to validate a Strategy or Risk Profile before going live. All Contracts trade in paper mode simultaneously — mixed paper/live operation is not supported.
+
+### Position
+The open futures exposure held by the bot — either LONG or SHORT. Represents the full round-trip lifecycle: opened when an entry order fills, closed when an exit order fills. Tracks entry price, exit price, side, PnL, stop-loss target, and take-profit target. Industry standard term; maps to the `Position` model.
+
+### Risk Profile
+A named, versioned set of capital and risk parameters: take-profit target, stop-loss target, risk fraction, position size limits, confidence thresholds. Answers *how much* to trade and *at what risk*. Only one profile is active at a time; the bot falls back to environment variables if none is active. Maps to the `TradingProfile` model.
+
+### Rollover
+The operational process of closing a Position on a near-expiry Contract and switching to the next Contract. Triggered by calendar (N days before expiry) — not a trading decision. Whether a new Position opens on the replacement Contract depends solely on whether the Strategy generates a fresh Signal.
+
+### Sentiment
+A scored measure of market mood for a given underlying, derived from news and event feeds. Feeds into Signal confidence as a soft input — does not gate entries independently. Sources are asset-specific: crypto-focused feeds (e.g. CryptoPanic) for crypto contracts; macro/geopolitical feeds (e.g. Reuters, EIA reports) for commodity contracts. Maps to `SentimentEvent` (raw) and `SentimentAggregate` (time-windowed z-score summaries).
+
+### Signal
+A candidate trade opportunity produced by a Strategy. Carries a side (LONG/SHORT), signal type (entry/exit/stop-loss/take-profit), confidence percentage, and timeframe. A Signal may expire or be cancelled without ever opening a Position. Maps to the `SignalAlert` model.
+
+### Strategy
+The algorithm that analyzes market data and produces Signals. Answers *when* to trade — entry and exit conditions, timeframe logic, confidence scoring. Distinct from Risk Profile. Maps to the `Strategy::*` service classes.
+
+### Swing Trade
+A Position with no intraday closure requirement. Held across days until stop-loss, take-profit, or manual exit. A per-Position property; contrast with Day Trade.
+
+### Timeframe
+The candlestick resolution used by a Strategy — e.g. 1m, 5m, 15m, 1h, 1d. Different Underlyings may use different timeframe sets (e.g. daily timeframes matter more for commodities driven by weekly reports). **Open question:** whether available timeframes are constrained by what Coinbase's API supports or are freely configurable per-Underlying. See [#195](https://github.com/Skeyelab/coinbase_futures_bot/issues/195).
+
+### Underlying
+The asset a Contract is based on — e.g. BTC, ETH, crude oil. A first-class grouping concept: Contracts sharing the same Underlying share sentiment sources, Strategy configuration, and Risk Profile assignment. Rollover moves between Contracts within the same Underlying. Not currently a model in the code — parsed implicitly from the Contract product ID prefix.

--- a/docs/adr/0001-orders-as-first-class-records.md
+++ b/docs/adr/0001-orders-as-first-class-records.md
@@ -1,0 +1,24 @@
+# ADR 0001: Orders as First-Class Records
+
+**Date:** 2026-06-04
+**Status:** Accepted
+
+## Context
+
+The bot opens and closes Positions by placing orders on the Coinbase API. Currently, orders are ephemeral — the API call is made, and the Position model records the resulting entry or exit price. No order record is stored.
+
+The Position model answers "what exposure do we have?" but cannot answer:
+- Did the fill price match the Signal's target price, or was there slippage?
+- What happened to an order placed during a network outage — was it filled, partially filled, or rejected?
+- Why did a Position open at a price different from what the Strategy intended?
+
+## Decision
+
+Orders are a first-class domain concept. Every order placed on Coinbase will be stored as an `Order` record, associated with the Position it opens or closes. The Order captures the intended price, the actual fill price, quantity, order type, and exchange order ID.
+
+## Consequences
+
+- Slippage is auditable: compare `Order#target_price` with `Order#fill_price`.
+- Outage recovery is possible: on restart, the bot can query Coinbase for pending order status and reconcile against stored records.
+- Position entry/exit prices become derivable from Orders rather than stored independently — the Position is the net result of its Orders.
+- Adds an `Order` model and migration; existing Positions have no associated Orders and represent a data gap pre-adoption.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,14 @@
+# Domain Docs
+
+**Layout:** single-context
+
+## Files
+
+- `CONTEXT.md` — domain language, bounded contexts, key concepts (create if missing)
+- `docs/adr/` — architectural decision records (create if missing)
+
+## Rules for agents
+
+1. Read `CONTEXT.md` before any domain reasoning.
+2. New ADRs go in `docs/adr/NNNN-<slug>.md`.
+3. If `CONTEXT.md` missing, note it and proceed with codebase inference.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,29 @@
+# Issue Tracker
+
+**Type:** GitHub Issues
+**Repo:** Skeyelab/coinbase_futures_bot
+**CLI:** `gh`
+
+## Creating issues
+
+```bash
+gh issue create --title "..." --body "..."
+```
+
+## Listing issues
+
+```bash
+gh issue list
+```
+
+## Closing issues
+
+```bash
+gh issue close <number>
+```
+
+## Labelling
+
+```bash
+gh issue edit <number> --add-label "<label>"
+```

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,9 @@
+# Triage Labels
+
+| Role | Label |
+|---|---|
+| Maintainer needs to evaluate | `needs-triage` |
+| Waiting on reporter | `needs-info` |
+| Fully specified, agent can pick up | `ready-for-agent` |
+| Needs human implementation | `ready-for-human` |
+| Will not be actioned | `wontfix` |


### PR DESCRIPTION
## Summary

- Adds `## Agent skills` section to `CLAUDE.md` — wires up GitHub Issues tracker, default triage labels, and single-context domain docs for Matt Pocock engineering skills (`to-issues`, `triage`, `to-prd`, `qa`, etc.)
- Adds `docs/agents/` with `issue-tracker.md`, `triage-labels.md`, and `domain.md`
- Adds `CONTEXT.md` with a 14-term domain glossary (Basis, Confidence, Contract, Day Trade, Order, Paper Trading, Position, Risk Profile, Rollover, Sentiment, Signal, Strategy, Swing Trade, Timeframe, Underlying) — established via domain grilling session
- Adds `docs/adr/0001-orders-as-first-class-records.md` — decision to store Orders as first-class records for slippage auditing and outage recovery

## Test plan

- [ ] `CLAUDE.md` renders correctly on GitHub
- [ ] `CONTEXT.md` glossary terms are accurate to the codebase
- [ ] `docs/agents/` files are readable and actionable by agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)