### PR TITLE
Add Conductor setup script

### DIFF
--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -26,6 +26,17 @@
 
 ### Session log
 
+#### 2026-06-04 15:44 UTC
+- Context: Added shared Conductor workspace setup for this Rails repo.
+- Changes:
+  - Created root `conductor.json` with `scripts.setup` only.
+  - Setup script reuses root `.env` via symlink when present, runs `bundle check || bundle install`, then `bin/rails db:prepare`.
+  - Intentionally avoided `bin/setup` because it mutates git hooks and restarts the app.
+- Files touched:
+  - `conductor.json`, `SESSION_NOTES.md`
+- Next steps:
+  - If teammates want copied env files instead of symlinks, move that concern to Conductor Files to copy or `.worktreeinclude`.
+
 #### 2026-04-30 00:00 UTC
 - Context: Finished merge of `origin/main` into `feat/signals-longshort-guard-api-cleanup` for PR #181; resolved conflicts.
 - Changes:
@@ -3553,5 +3564,4 @@
 - Next steps:
   - Integrate sentiment feature into live execution flow when confidence is validated.
   - Consider FinBERT/ONNX scorer and Reddit source.
-
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "setup": "if [ -f \"$CONDUCTOR_ROOT_PATH/.env\" ] && [ ! -e .env ]; then ln -s \"$CONDUCTOR_ROOT_PATH/.env\" .env; fi\nbundle check || bundle install\nbin/rails db:prepare"
+  }
+}


### PR DESCRIPTION
Adds a shared `conductor.json` for Conductor workspaces in this Rails repo.
The setup script symlinks the root `.env` into each workspace when available, installs gems only when needed, and prepares the database.
This intentionally avoids `bin/setup`, which also mutates git hooks and restarts the app.
The workspace session log was updated to record the Conductor setup change.
Validation: `ruby -rjson -e 'JSON.parse(File.read("conductor.json"))'`.
