### PR TITLE
docs: switch workflow docs to GitHub Issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,9 @@
 
 ## Learned Workspace Facts
 
-- This workspace uses `bd` (beads) as the primary issue tracker workflow.
-- Running `bd prime` is expected before active issue execution.
-- Beads dependency ordering is managed explicitly with `bd dep add`.
-- Issue planning often spans both GitHub issues and Beads dependencies.
+- This workspace uses GitHub Issues as the only issue tracker workflow.
+- Use `gh` for issue listing, review, editing, and closure.
+- Express dependency/order in GitHub issue bodies, linked issues, or PR references rather than a secondary tracker.
 
 ## What this repo is
 
@@ -55,12 +54,13 @@
 - Day trading close workflow: `bin/rake day_trading:manage`
 - Kill switch: `bin/futuresbot halt [--reason "..."]` / `bin/futuresbot resume`
 
-### Beads issue tracker
+### GitHub issue tracker
 
-- List issues: `bd list` / `bd ready`
-- Sync with GitHub: `GITHUB_TOKEN="$(gh auth token)" bd github sync`
-  - Note: `bd config set github.token` is written to config.yaml but not read by `bd github sync` (bd bug); use the env var workaround above.
-- Push to Dolt remote: `bd dolt push` (no remote configured yet)
+- List issues: `gh issue list`
+- View issue: `gh issue view <number>`
+- Create issue: `gh issue create`
+- Edit issue: `gh issue edit <number>`
+- Close issue: `gh issue close <number>`
 
 ## High-value gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,25 +2,25 @@
 
 This file provides instructions and context for AI coding agents working on this project.
 
-<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
-## Beads Issue Tracker
+## GitHub Issue Tracker
 
-This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+This project uses GitHub Issues only. Use the `gh` CLI for issue workflow.
 
 ### Quick Reference
 
 ```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --claim  # Claim work
-bd close <id>         # Complete work
+gh issue list
+gh issue view <number>
+gh issue create
+gh issue edit <number>
+gh issue close <number>
 ```
 
 ### Rules
 
-- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
-- Run `bd prime` for detailed command reference and session close protocol
-- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- Use GitHub Issues for tracked work. Do NOT use secondary issue trackers.
+- Keep issue bodies agent-ready with explicit scope and acceptance criteria.
+- Express dependencies/order with GitHub issue links, body text, or PR references.
 
 ## Session Completion
 
@@ -34,7 +34,6 @@ bd close <id>         # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```
@@ -47,7 +46,6 @@ bd close <id>         # Complete work
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
-<!-- END BEADS INTEGRATION -->
 
 
 ## Build & Test


### PR DESCRIPTION
## Summary
- remove `bd` / Beads workflow guidance from agent docs
- document GitHub Issues as the only tracking workflow
- replace `bd` command examples with `gh` equivalents

## Testing
- not run (doc-only change)
