### PR TITLE
docs: add focused operator wiki pages

### DIFF
--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -1,0 +1,175 @@
+# CLI Reference
+
+`bin/futuresbot` is the repo's terminal-first operator interface.
+
+## Quick Check
+
+```bash
+bin/futuresbot help
+bin/futuresbot version
+```
+
+## Commands
+
+### `dashboard`
+
+Launch the real-time TUI dashboard. This is the default command when no subcommand is given.
+
+```bash
+bin/futuresbot
+bin/futuresbot dashboard
+bin/futuresbot dashboard --refresh 10
+```
+
+Options:
+- `--refresh`, `-r`, `-i`: refresh interval in seconds
+
+Current key bindings:
+- `q`, `Q`, `Esc`, `Ctrl-C`: quit
+- `r`, `R`: force refresh
+- `p`, `P`: toggle positions section
+- `s`, `S`: toggle signals section
+- `i`, `I`: import/sync positions from Coinbase
+- `c`, `C`: close an open position
+- `o`, `O`: reconcile local open rows missing from exchange
+- `h`, `H`: toggle trading halt state
+- `+`, `=` or Up arrow: faster refresh
+- `-` or Down arrow: slower refresh
+- Left / Right arrows: toggle positions / signals
+
+Notes:
+- `dashboard` syncs positions on startup unless `FUTURESBOT_SKIP_POSITION_SYNC=1`.
+- The dashboard reads local DB state and recent market data; it does not replace the API.
+
+### `chat`
+
+Start an interactive chat session.
+
+```bash
+bin/futuresbot chat
+bin/futuresbot chat --resume
+bin/futuresbot chat --session-id <uuid>
+```
+
+Options:
+- `--resume`, `-r`: resume most recent active session
+- `--session-id`, `-s`: resume a specific session
+
+Local chat commands:
+
+```text
+history 10
+search btc
+sessions
+context-status
+quit
+```
+
+### `status`
+
+Show a short system summary.
+
+```bash
+bin/futuresbot status
+```
+
+### `positions`
+
+List open positions.
+
+```bash
+bin/futuresbot positions
+bin/futuresbot positions --type day
+bin/futuresbot positions --type swing
+bin/futuresbot positions --limit 5
+```
+
+Options:
+- `--type`, `-t`: `day` or `swing`
+- `--limit`, `-n`: max rows
+
+### `signals`
+
+List recent active signals.
+
+```bash
+bin/futuresbot signals
+bin/futuresbot signals --limit 25
+bin/futuresbot signals --min-confidence 75
+```
+
+Options:
+- `--limit`, `-n`: max rows
+- `--min-confidence`, `-c`: minimum confidence threshold
+
+### `halt`
+
+Trigger the trading kill switch.
+
+```bash
+bin/futuresbot halt
+bin/futuresbot halt --reason "manual stop"
+```
+
+### `resume`
+
+Resume trading after a halt.
+
+```bash
+bin/futuresbot resume
+```
+
+### `halt_status`
+
+Show current kill-switch state.
+
+```bash
+bin/futuresbot halt_status
+```
+
+### `version`
+
+Show runtime version info.
+
+```bash
+bin/futuresbot version
+```
+
+### `help`
+
+```bash
+bin/futuresbot help
+bin/futuresbot help dashboard
+```
+
+### `tree`
+
+Show the command tree.
+
+```bash
+bin/futuresbot tree
+```
+
+## Related Rake Tasks
+
+Use rake for one-shot or scheduled operational flows:
+
+```bash
+bin/rake realtime:signals
+bin/rake realtime:evaluate
+bin/rake "realtime:evaluate_symbol[BIT-29AUG25-CDE]"
+bin/rake realtime:stats
+bin/rake day_trading:manage
+bin/rake day_trading:pnl
+```
+
+## Startup Behavior
+
+- `dashboard` and `chat` perform startup position sync unless `FUTURESBOT_SKIP_POSITION_SYNC=1`.
+- The CLI works best with the Rails app and GoodJob worker already running.
+
+## See Also
+
+- [User Guide](User-Guide)
+- [Day-Trading-Guide](Day-Trading-Guide)
+- [Monitoring](Monitoring)

--- a/wiki/Day-Trading-Guide.md
+++ b/wiki/Day-Trading-Guide.md
@@ -1,0 +1,157 @@
+# Day Trading Guide
+
+This guide covers the repo's day-trading workflows: same-day positions, closure automation, operator tasks, and emergency controls.
+
+## Overview
+
+Day-trading positions are positions with `day_trading=true`. They are expected to close within 24 hours and are managed separately from swing-trading positions.
+
+Related code paths:
+- `Trading::DayTradingPositionManager`
+- `DayTradingPositionManagementJob`
+- `EndOfDayPositionClosureJob`
+
+## Quick Start
+
+```bash
+export DEFAULT_DAY_TRADING=true
+export SIGNAL_EQUITY_USD=5000
+export RISK_PER_TRADE_PERCENT=2
+export REALTIME_SIGNAL_MIN_CONFIDENCE=65
+
+bin/rails server
+bundle exec good_job start
+SIGNAL_EQUITY_USD=5000 bin/rake realtime:signals
+```
+
+Monitor in another terminal:
+
+```bash
+bin/rake day_trading:check_positions
+bin/futuresbot positions --type day
+```
+
+## Common Tasks
+
+### Monitoring
+
+```bash
+bin/rake day_trading:check_positions
+bin/rake day_trading:pnl
+bin/rake day_trading:details
+```
+
+### Management
+
+```bash
+bin/rake day_trading:close_expired
+bin/rake day_trading:close_approaching
+bin/rake day_trading:check_tp_sl
+bin/rake day_trading:manage
+```
+
+### Emergency
+
+```bash
+bin/rake day_trading:force_close_all
+bin/futuresbot halt --reason "day-trading incident"
+FORCE=true bin/rake realtime:cancel_all
+```
+
+### Maintenance
+
+```bash
+bin/rake day_trading:cleanup
+```
+
+Note: some operational tasks support or expect `FORCE=true` in non-interactive runs.
+
+## Background Automation
+
+With GoodJob running, the repo schedules day-trading automation through background jobs. At minimum, expect:
+- periodic day-trading management
+- end-of-day forced closure for remaining day-trading positions
+
+GoodJob dashboard in development:
+
+```text
+http://localhost:3000/good_job
+```
+
+## Position and Exposure Views
+
+### API
+
+```bash
+curl "http://localhost:3000/api/positions?type=day_trading"
+curl http://localhost:3000/api/positions/summary
+curl http://localhost:3000/api/positions/exposure
+```
+
+### Web UI
+
+```text
+http://localhost:3000/positions
+```
+
+### CLI
+
+```bash
+bin/futuresbot status
+bin/futuresbot positions --type day
+bin/futuresbot signals --min-confidence 75
+```
+
+## Useful Configuration
+
+```bash
+DEFAULT_DAY_TRADING=true
+SIGNAL_EQUITY_USD=5000
+RISK_PER_TRADE_PERCENT=2
+REALTIME_SIGNAL_MIN_CONFIDENCE=65
+REALTIME_SIGNAL_MAX_PER_HOUR=8
+REALTIME_SIGNAL_EVALUATION_INTERVAL=45
+REALTIME_SIGNAL_DEDUPE_WINDOW=300
+```
+
+## Troubleshooting
+
+### Positions are not closing automatically
+
+Check:
+
+```bash
+bundle exec good_job start
+curl http://localhost:3000/health
+bin/rake day_trading:check_positions
+bin/rake day_trading:manage
+```
+
+Inspect logs:
+
+```bash
+tail -f log/development.log | grep -E "DayTrading|Position|GoodJob"
+```
+
+### TP/SL actions look stale
+
+Check whether recent market data exists for the product:
+
+```bash
+bin/rake "market_data:subscribe[BTC-USD]"
+bin/rake realtime:stats
+```
+
+### Need to stop everything quickly
+
+```bash
+bin/futuresbot halt --reason "operator stop"
+bin/futuresbot halt_status
+bin/rake day_trading:force_close_all
+```
+
+## See Also
+
+- [User Guide](User-Guide)
+- [CLI Reference](CLI-Reference)
+- [Monitoring](Monitoring)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,120 +2,61 @@
 
 [![CI Status](https://github.com/Skeyelab/coinbase_futures_bot/workflows/CI/badge.svg)](https://github.com/Skeyelab/coinbase_futures_bot/actions)
 
-Welcome to the comprehensive documentation for the **Coinbase Futures Bot** - an automated cryptocurrency futures trading system built with Rails 8.0.
+Welcome to the documentation wiki for the **Coinbase Futures Bot**. This repo is a Rails 8 futures trading system with market-data ingestion, signal generation, automated position management, a terminal UI, chat tooling, and operational health endpoints.
 
-## 🚀 Quick Navigation
+## Quick Navigation
 
-### 📚 Getting Started
-- **[Getting Started](Getting-Started)** - Complete setup guide with prerequisites
-- **[Configuration](Configuration)** - Environment variables and settings
-- **[Development](Development)** - Local development workflow and tools
+### Start Here
+- **[Getting Started](Getting-Started)** - local setup and boot flow
+- **[Configuration](Configuration)** - environment variables and runtime settings
+- **[User Guide](User-Guide)** - operator workflows across CLI, API, web UI, and rake tasks
+- **[CLI Reference](CLI-Reference)** - exact `bin/futuresbot` command surface
+- **[Monitoring](Monitoring)** - health checks, queue visibility, and incident controls
 
-### 🏗️ Architecture & Design
-- **[Architecture Overview](Architecture)** - System design and component relationships
-- **[Database Schema](Database-Schema)** - Models, relationships, and data structures
-- **[API Reference](API-Reference)** - REST API endpoints with examples
+### Core Reference
+- **[Architecture](Architecture)** - high-level system design
+- **[Database Schema](Database-Schema)** - models and relationships
+- **[API Reference](API-Reference)** - HTTP endpoints
+- **[Services Guide](Services-Guide)** - major service objects
+- **[Background Jobs](Background-Jobs)** - scheduled and asynchronous workflows
+- **[Trading Strategies](Trading-Strategies)** - strategy documentation
+- **[Testing Guide](Testing-Guide)** - test structure and conventions
+- **[Troubleshooting](Troubleshooting)** - common failure modes
+- **[Contributing](Contributing)** - contribution workflow
 
-### 🔧 Core Components
-- **[Services Guide](Services-Guide)** - Business logic services (38 services)
-- **[Background Jobs](Background-Jobs)** - Job system and scheduling (25+ jobs)
-- **[Trading Strategies](Trading-Strategies)** - Strategy implementation and parameters
-- **[WebSocket Integration](WebSocket-Integration)** - Real-time data streaming
+## Project Snapshot
 
-### 📊 Trading & Operations
-- **[Day Trading Guide](Day-Trading-Guide)** - Intraday trading strategies and risk management
-- **[Risk Management](Risk-Management)** - Position sizing, stops, and safety controls
-- **[Market Data Pipeline](Market-Data-Pipeline)** - Data ingestion and processing
-- **[Sentiment Analysis](Sentiment-Analysis)** - News sentiment integration and scoring
+- **Runtime**: Ruby `3.2.4`, Rails `8.x`, PostgreSQL, GoodJob, RSpec, StandardRB, Brakeman
+- **Trading model**: both day-trading and swing-trading positions exist
+- **Contract model**: repo is centered on expiring Coinbase futures contracts, not perpetuals
+- **Primary operator surfaces**: `bin/futuresbot`, `bin/rake`, `/positions`, `/signals/*`, `/health`, `/up`
 
-### 🛠️ Development & Testing
-- **[Testing Guide](Testing-Guide)** - Test suite organization and best practices
-- **[Code Organization](Code-Organization)** - File structure and patterns
-- **[Contributing](Contributing)** - Development workflow and standards
+## Operator Entry Points
 
-### 🚀 Operations & Deployment
-- **[Deployment Guide](Deployment)** - Production deployment and operations
-- **[Monitoring & Observability](Monitoring)** - Health checks, logging, and alerts
-- **[Troubleshooting](Troubleshooting)** - Common issues and solutions
+### Terminal
+- `bin/futuresbot` - default TUI dashboard
+- `bin/futuresbot chat` - interactive trading/operator chat
+- `bin/futuresbot status` - quick system summary
+- `bin/rake realtime:signals` - start the real-time signal loop
+- `bin/rake day_trading:manage` - run day-trading management once
 
-## 📈 Project Overview
+### Web / HTTP
+- `/up` - basic Rails health
+- `/health` - extended application health
+- `/positions` - server-rendered positions UI
+- `/signals/active`, `/signals/high_confidence`, `/signals/recent`, `/signals/stats`, `/signals/health`
+- `/api/positions`, `/api/positions/summary`, `/api/positions/exposure`
 
-The Coinbase Futures Bot is a sophisticated **day trading** system designed for short-term intraday positions with rapid entry/exit cycles. It features:
-
-### Core Features
-- **Multi-timeframe Trading**: 1h trend, 15m confirmation, 5m entry, 1m micro-timing
-- **Real-time Market Data**: WebSocket integration with Coinbase APIs
-- **Sentiment Analysis**: News sentiment integration with CryptoPanic
-- **Risk Management**: Position sizing, stop losses, and futures contract management
-- **Paper Trading**: Comprehensive simulation and backtesting
-- **Background Processing**: Reliable job processing with GoodJob
-
-### Technology Stack
-- **Framework**: Rails 8.0 (API-only)
-- **Language**: Ruby 3.2.4
-- **Database**: PostgreSQL with time-series optimizations
-- **Jobs**: GoodJob with cron scheduling
-- **Testing**: RSpec with 94 test files and comprehensive coverage
-- **APIs**: Coinbase Advanced Trade, Exchange API, CryptoPanic
-
-## 📊 System Statistics
-
-| Component | Count | Description |
-|-----------|-------|-------------|
-| **Services** | 38 | Business logic services across 6 modules |
-| **Background Jobs** | 25+ | Scheduled and event-driven jobs |
-| **API Endpoints** | 20+ | REST API with real-time WebSocket |
-| **Database Tables** | 8 | Optimized for time-series data |
-| **Test Files** | 94 | Comprehensive test coverage |
-| **Documentation Pages** | 15+ | This wiki system |
-
-## 🎯 Day Trading Focus
-
-This system is specifically optimized for **intraday trading** with:
-
-- **Position Duration**: Maximum 4-8 hours, typically 1-4 hours
-- **Entry Precision**: 1-minute and 5-minute timeframe analysis
-- **Risk Management**: Tighter stops (20-40 bps) for day trading
-- **Exit Strategy**: Aggressive take-profit targets for quick wins
-- **Market Hours**: Focus on high-liquidity periods
-
-## 🔗 Quick Links
-
-### Development Resources
+### Repository
 - **GitHub Repository**: [Skeyelab/coinbase_futures_bot](https://github.com/Skeyelab/coinbase_futures_bot)
 - **CI/CD Pipeline**: [GitHub Actions](https://github.com/Skeyelab/coinbase_futures_bot/actions)
-- **Issue Tracking**: [Linear - FuturesBot Project](https://linear.app/ericdahl/project/futuresbot-c639185ec497/overview)
+- **Issue Tracking**: GitHub Issues
 
-### API Documentation
-- **Health Check**: `/up` - Basic health status
-- **Extended Health**: `/health` - Database and system status
-- **Real-time Signals**: `/signals` - Trading signal API
-- **Position Management**: `/positions` - Position tracking UI
-- **GoodJob Dashboard**: `/good_job` (development only)
+## Notes
 
-### Key Configuration Files
-- **Application Config**: `config/application.rb`
-- **Database Schema**: `db/schema.rb`
-- **Routes**: `config/routes.rb`
-- **Job Schedules**: Defined in individual job classes
-
-## 📝 Documentation Standards
-
-This wiki follows these standards:
-
-1. **Code Examples**: All major features include working code examples
-2. **API Documentation**: Complete with curl examples and response formats
-3. **Cross-References**: Extensive linking between related topics
-4. **Maintenance**: Regular updates aligned with code changes
-5. **Search Optimization**: Clear headings and consistent terminology
-
-## 🆘 Getting Help
-
-- **Setup Issues**: See [Getting Started](Getting-Started) and [Troubleshooting](Troubleshooting)
-- **API Questions**: Check [API Reference](API-Reference) and [Services Guide](Services-Guide)
-- **Trading Strategy**: Review [Trading Strategies](Trading-Strategies) and [Day Trading Guide](Day-Trading-Guide)
-- **Development**: Follow [Development](Development) and [Contributing](Contributing) guides
+- For operational truth, prefer code and current runtime docs over older prose.
+- Wiki content syncs from the repository `wiki/` directory on pushes to `main`.
 
 ---
 
-**Last Updated**: January 2025 | **Version**: Rails 8.0 | **Ruby**: 3.2.4
+**Last Updated**: 2026-06-04

--- a/wiki/Monitoring.md
+++ b/wiki/Monitoring.md
@@ -1,0 +1,124 @@
+# Monitoring
+
+This page collects the main health, queue, log, and operator controls for the current repo.
+
+## Health Endpoints
+
+### Rails health
+
+```bash
+curl http://localhost:3000/up
+```
+
+### Extended app health
+
+```bash
+curl http://localhost:3000/health
+```
+
+### Signal system health
+
+```bash
+curl http://localhost:3000/signals/health
+```
+
+### Slack health
+
+```bash
+curl http://localhost:3000/slack/health
+```
+
+## Queue / Background Jobs
+
+Start worker locally:
+
+```bash
+bundle exec good_job start
+```
+
+Development dashboard:
+
+```text
+http://localhost:3000/good_job
+```
+
+Use it to inspect:
+- queued jobs
+- failed jobs
+- retries / reschedules
+- cron-backed recurring work
+
+## CLI Monitoring
+
+```bash
+bin/futuresbot
+bin/futuresbot status
+bin/futuresbot positions
+bin/futuresbot signals --min-confidence 75
+bin/futuresbot halt_status
+```
+
+## Signal Monitoring
+
+```bash
+bin/rake realtime:stats
+curl -H "X-API-Key: $SIGNALS_API_KEY" http://localhost:3000/signals/active
+curl -H "X-API-Key: $SIGNALS_API_KEY" "http://localhost:3000/signals/stats?hours=24"
+curl -H "X-API-Key: $SIGNALS_API_KEY" "http://localhost:3000/signals/recent?hours=1"
+```
+
+## Position Monitoring
+
+```bash
+bin/rake day_trading:check_positions
+bin/rake day_trading:pnl
+curl http://localhost:3000/api/positions/summary
+curl http://localhost:3000/api/positions/exposure
+```
+
+## Logs
+
+Application log:
+
+```bash
+tail -f log/development.log
+```
+
+Useful filters:
+
+```bash
+tail -f log/development.log | grep -E "Signal|Position|Coinbase|GoodJob|TradingHalt"
+tail -f log/development.log | grep -i error
+```
+
+## Incident Controls
+
+Kill switch:
+
+```bash
+bin/futuresbot halt --reason "incident"
+bin/futuresbot halt_status
+bin/futuresbot resume
+```
+
+Signal cleanup:
+
+```bash
+FORCE=true bin/rake realtime:cancel_all
+bin/rake realtime:cleanup
+```
+
+## Local Readiness Checklist
+
+- `/up` returns success
+- `/health` returns success
+- GoodJob worker is running
+- `/signals/health` is reachable if signal workflows matter for the task
+- `bin/futuresbot halt_status` shows expected kill-switch state
+- `SIGNALS_API_KEY` is set before using authenticated signal endpoints
+
+## See Also
+
+- [User Guide](User-Guide)
+- [CLI Reference](CLI-Reference)
+- [Day-Trading-Guide](Day-Trading-Guide)

--- a/wiki/User-Guide.md
+++ b/wiki/User-Guide.md
@@ -1,0 +1,193 @@
+# User Guide
+
+This guide covers the current operator-facing surfaces in the repo: terminal CLI, chat, HTTP APIs, the positions web UI, and the main rake entrypoints.
+
+## Accessing the Bot
+
+| Surface | Use it for | Command / URL |
+|---|---|---|
+| `bin/futuresbot` | TUI dashboard and quick inspection | `bin/futuresbot` |
+| `bin/futuresbot chat` | conversational operator workflow | `bin/futuresbot chat` |
+| Signals API | signal inspection and manual evaluation | `/signals/*` |
+| Positions API | position listings and exposure summaries | `/api/positions/*` |
+| Positions UI | server-rendered position management | `/positions` |
+| Rake tasks | one-shot operational actions | `bin/rake ...` |
+
+## Before You Start
+
+For local use, start the app and worker first:
+
+```bash
+bin/rails server
+bundle exec good_job start
+```
+
+Optional real-time loop:
+
+```bash
+bin/rake realtime:signals
+```
+
+Health checks:
+
+```bash
+curl http://localhost:3000/up
+curl http://localhost:3000/health
+```
+
+Notes:
+- `bin/futuresbot dashboard` and `bin/futuresbot chat` sync positions from Coinbase on startup unless `FUTURESBOT_SKIP_POSITION_SYNC=1`.
+- Most `/signals/*` endpoints require `SIGNALS_API_KEY` via `X-API-Key` header or `api_key` query param.
+
+## Analyze the Market
+
+### Chat
+
+```bash
+bin/futuresbot chat
+```
+
+Examples:
+
+```text
+BTC price
+show recent trading alerts
+what signals are active?
+analyze BTC market conditions
+show my positions
+```
+
+Local chat commands that do not invoke the AI:
+
+```text
+history 10
+search btc
+sessions
+context-status
+quit
+```
+
+### Signals API
+
+```bash
+curl -H "X-API-Key: $SIGNALS_API_KEY" http://localhost:3000/signals/active
+curl -H "X-API-Key: $SIGNALS_API_KEY" "http://localhost:3000/signals/high_confidence?threshold=80"
+curl -H "X-API-Key: $SIGNALS_API_KEY" "http://localhost:3000/signals/recent?hours=1"
+curl -H "X-API-Key: $SIGNALS_API_KEY" "http://localhost:3000/signals/stats?hours=24"
+curl -H "X-API-Key: $SIGNALS_API_KEY" "http://localhost:3000/signals?symbol=BIT-29AUG25-CDE&min_confidence=70"
+```
+
+Sentiment aggregates:
+
+```bash
+curl "http://localhost:3000/sentiment/aggregates?symbol=BTC-USD&window=15m"
+```
+
+### Manual Signal Evaluation
+
+Evaluate all enabled pairs:
+
+```bash
+curl -X POST -H "X-API-Key: $SIGNALS_API_KEY" http://localhost:3000/signals/evaluate
+bin/rake realtime:evaluate
+```
+
+Evaluate one symbol / product id:
+
+```bash
+curl -X POST -H "X-API-Key: $SIGNALS_API_KEY" \
+  "http://localhost:3000/signals/evaluate?symbol=BIT-29AUG25-CDE"
+
+bin/rake "realtime:evaluate_symbol[BIT-29AUG25-CDE]"
+```
+
+### Market Data Tasks
+
+```bash
+bin/rake "market_data:backfill_1h_candles[2]"
+bin/rake "market_data:subscribe[BTC-USD]"
+PRODUCT_IDS=BTC-USD,ETH-USD bin/rake market_data:subscribe
+```
+
+## Trading Controls
+
+### Kill Switch
+
+```bash
+bin/futuresbot halt --reason "manual stop"
+bin/futuresbot halt_status
+bin/futuresbot resume
+```
+
+### Signal Loop
+
+```bash
+bin/rake realtime:signals
+bin/rake realtime:signal_job
+bin/rake realtime:stats
+FORCE=true bin/rake realtime:cancel_all
+```
+
+### Paper / Live Safety
+
+- Use paper-trading configuration until you trust strategy behavior.
+- Treat `.env.example` as shape only, not real credentials.
+- The repo centers on expiring futures contracts; use real contract/product ids where required.
+
+## Watch Positions
+
+### CLI
+
+```bash
+bin/futuresbot status
+bin/futuresbot positions
+bin/futuresbot positions --type day
+bin/futuresbot positions --type swing
+bin/futuresbot signals --min-confidence 75
+```
+
+### Web UI
+
+Open:
+
+```text
+http://localhost:3000/positions
+```
+
+The positions UI uses HTTP Basic auth via `POSITIONS_UI_USERNAME` and `POSITIONS_UI_PASSWORD`.
+
+### Positions API
+
+```bash
+curl http://localhost:3000/api/positions
+curl "http://localhost:3000/api/positions?type=day_trading"
+curl "http://localhost:3000/api/positions?type=swing_trading"
+curl http://localhost:3000/api/positions/summary
+curl http://localhost:3000/api/positions/exposure
+```
+
+## Day-Trading Operations
+
+Common tasks:
+
+```bash
+bin/rake day_trading:check_positions
+bin/rake day_trading:pnl
+bin/rake day_trading:details
+bin/rake day_trading:manage
+```
+
+See [Day-Trading-Guide](Day-Trading-Guide) for the full task list.
+
+## Monitoring and Incident Response
+
+Start here during incidents:
+
+```bash
+curl http://localhost:3000/health
+curl http://localhost:3000/signals/health
+bin/futuresbot halt_status
+bin/rake realtime:stats
+```
+
+See [Monitoring](Monitoring) for the full operational checklist.


### PR DESCRIPTION
## Summary
- add current operator wiki pages for user guide, CLI reference, day-trading operations, and monitoring
- refresh `wiki/Home.md` to remove stale framing and dead navigation
- keep scope tight to current repo surfaces instead of reviving the broader stale docs branch

## Context
This PR replaces the direction of closed PR #146 with a smaller, current-main-based docs update.

## Testing
- not run (wiki/docs-only change)
