### PR TITLE
ci: skip source checks for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,44 +12,108 @@ env:
   COVERAGE: true
 
 jobs:
+  changes:
+    name: Detect Changed Files
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changes
+        id: classify
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE_REF="${GITHUB_BASE_REF:-main}"
+          git fetch origin "$BASE_REF" --depth=1
+
+          CHANGED_FILES="$(git diff --name-only "origin/$BASE_REF...HEAD")"
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          DOCS_ONLY=true
+          while IFS= read -r file; do
+            case "$file" in
+              README.md|SESSION_NOTES.md|AGENTS.md|CLAUDE.md|CONTEXT.md|docs/*|wiki/*|.github/**/*.md|.beads/*)
+                ;;
+              *)
+                DOCS_ONLY=false
+                break
+                ;;
+            esac
+          done <<EOF
+          $CHANGED_FILES
+          EOF
+
+          echo "docs_only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
+
   lint:
     name: StandardRB (lint)
     runs-on: ubuntu-latest
+    needs: [changes]
     steps:
       - uses: actions/checkout@v6
 
       - uses: ruby/setup-ruby@v1
+        if: needs.changes.outputs.docs_only != 'true'
         with:
           ruby-version-file: '.ruby-version'
           bundler-cache: true
 
       - name: Lint code
+        if: needs.changes.outputs.docs_only != 'true'
         run: bin/standardrb
+
+      - name: Skip lint for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only PR -> skipping StandardRB"
 
   security:
     name: Security scans
     runs-on: ubuntu-latest
+    needs: [changes]
     steps:
       - uses: actions/checkout@v6
 
       - uses: ruby/setup-ruby@v1
+        if: needs.changes.outputs.docs_only != 'true'
         with:
           ruby-version-file: '.ruby-version'
           bundler-cache: true
 
       - name: Brakeman (static analysis)
+        if: needs.changes.outputs.docs_only != 'true'
         run: bin/brakeman --no-pager
 
       - name: Bundler Audit (dependency vulnerabilities)
+        if: needs.changes.outputs.docs_only != 'true'
         # Temporary ignore for pre-existing nokogiri advisories in this branch.
         # TODO(#187): remove these ignores once nokogiri is upgraded.
         # Keep auditing all other gems in the meantime.
         run: bundle exec bundler-audit check --update --ignore GHSA-c4rq-3m3g-8wgx --ignore GHSA-v2fc-qm4h-8hqv
 
+      - name: Skip security scans for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only PR -> skipping security scans"
+
   test:
     name: Rails tests with coverage
     runs-on: ubuntu-latest
-    needs: [lint, security]
+    needs: [changes, lint, security]
 
     services:
       postgres:
@@ -67,10 +131,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.docs_only != 'true'
         with:
           fetch-depth: 0  # Fetch full history for diff comparison
 
       - name: Find changed files and test files
+        if: needs.changes.outputs.docs_only != 'true'
         id: changed-files
         run: |
           echo "=== FINDING CHANGED FILES AND TEST FILES ==="
@@ -98,16 +164,19 @@ jobs:
           echo "has-changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
 
       - uses: ruby/setup-ruby@v1
+        if: needs.changes.outputs.docs_only != 'true'
         with:
           ruby-version-file: '.ruby-version'
           bundler-cache: true
 
       - name: Install system dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y libpq-dev pkg-config postgresql-client
 
       - name: Cache test database and artifacts
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -120,6 +189,7 @@ jobs:
             ${{ runner.os }}-test-cache-
 
       - name: Prepare database (create + migrate)
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           echo "Waiting for PostgreSQL service to be ready..."
           # Wait for PostgreSQL to be fully ready
@@ -136,6 +206,7 @@ jobs:
           echo "Database setup complete"
 
       - name: Debug environment
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           echo "=== WORKFLOW CACHE TEST - If you see this, cache is refreshed! ==="
           echo "Current timestamp: $(date +%s)"
@@ -157,6 +228,7 @@ jobs:
           echo "=== End Environment Debug ==="
 
       - name: Run tests with coverage
+        if: needs.changes.outputs.docs_only != 'true'
         timeout-minutes: 15
         env:
           # Force single-process execution - disable parallel testing
@@ -319,8 +391,8 @@ jobs:
           exit $TEST_EXIT_CODE
 
       - name: Upload coverage reports
+        if: always() && needs.changes.outputs.docs_only != 'true'
         uses: actions/upload-artifact@v7
-        if: always()
         with:
           name: coverage-reports-${{ github.run_number }}
           path: |
@@ -330,7 +402,7 @@ jobs:
           retention-days: 30
 
       - name: Check coverage thresholds
-        if: success()
+        if: success() && needs.changes.outputs.docs_only != 'true'
         run: |
           echo "=== COVERAGE THRESHOLD CHECK ==="
 
@@ -405,14 +477,23 @@ jobs:
             exit 1
           fi
 
+      - name: Skip tests for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only PR -> skipping Rails test suite"
+
   # Coverage badge generation - runs at the end of successful CI
   coverage-badge:
     name: Generate Coverage Badge
     runs-on: ubuntu-latest
-    needs: [lint, security, test]
+    needs: [changes, lint, security, test]
     if: always() && needs.lint.result == 'success' && needs.security.result == 'success' && needs.test.result == 'success'
     steps:
+      - name: Skip coverage badge for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only PR -> skipping coverage badge generation"
+
       - name: Download coverage artifacts
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/download-artifact@v8
         with:
           name: coverage-reports-${{ github.run_number }}
@@ -420,6 +501,7 @@ jobs:
         continue-on-error: true
 
       - name: Generate coverage badge
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           echo "=== COVERAGE BADGE GENERATION ==="
           echo "Looking for coverage data in: coverage/coverage.json"

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -26,6 +26,21 @@
 
 ### Session log
 
+#### 2026-06-04 20:50 UTC
+- Context: Added docs-only CI bypass so repo does not burn Ruby lint/test time on prose-only PRs.
+- Changes:
+  - Added `changes` job in `.github/workflows/ci.yml` to classify docs-only pull requests from changed paths.
+  - Kept existing required check names (`StandardRB (lint)`, `Security scans`, `Rails tests with coverage`, `Generate Coverage Badge`) but turned them into fast pass/no-op jobs for docs-only PRs.
+  - Left push-to-main behavior unchanged: full CI still runs outside pull requests.
+- Commands run:
+  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml-ok"'`
+  - `rg -n "docs_only|Docs-only PR" .github/workflows/ci.yml`
+- Files touched:
+  - `.github/workflows/ci.yml`
+  - `SESSION_NOTES.md`
+- Next steps:
+  - Open PR and verify one docs-only diff shows skipped/no-op lint/test jobs while code PRs still run full CI.
+
 #### 2026-06-04 20:34 UTC
 - Context: Refreshed PR #174 against `origin/main` to clear merge conflicts before manual landing.
 - Changes:


### PR DESCRIPTION
## Summary
- add a `changes` job to classify docs-only pull requests
- keep existing CI check names but make lint/security/test/badge jobs no-op on docs-only PRs
- leave push-to-main behavior unchanged so full CI still runs for real code changes

## Test plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml-ok"'`
- verify docs-only PRs show pass/no-op jobs for source checks
