### PR TITLE
feat(orders): implement Order model as first-class record

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Order < ApplicationRecord
+  SIDES = %w[buy sell].freeze
+  ORDER_TYPES = %w[market limit].freeze
+  STATUSES = %w[pending open filled cancelled failed].freeze
+
+  belongs_to :position, optional: true
+
+  validates :contract_id, presence: true
+  validates :side, presence: true, inclusion: {in: SIDES}
+  validates :order_type, presence: true, inclusion: {in: ORDER_TYPES}
+  validates :quantity, presence: true, numericality: {greater_than: 0}
+  validates :status, presence: true, inclusion: {in: STATUSES}
+  validates :coinbase_order_id, uniqueness: {allow_nil: true}
+
+  scope :for_position, ->(position) { where(position: position) }
+  scope :filled, -> { where(status: "filled") }
+  scope :pending, -> { where(status: "pending") }
+  scope :opening, -> { where(side: "buy") }
+  scope :closing, -> { where(side: "sell") }
+
+  def filled?
+    status == "filled"
+  end
+
+  def pending?
+    status == "pending"
+  end
+
+  def slippage
+    return nil unless target_price && fill_price && target_price > 0
+
+    fill_price - target_price
+  end
+
+  def slippage_bps
+    return nil unless slippage && target_price > 0
+
+    (slippage / target_price) * 10_000
+  end
+end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -49,6 +49,7 @@ class Position < ApplicationRecord
 
   # Associations
   belongs_to :trading_pair, primary_key: :product_id, foreign_key: :product_id, optional: true
+  has_many :orders, dependent: :nullify
 
   # Instance methods
   def open?

--- a/app/services/trading/coinbase_positions.rb
+++ b/app/services/trading/coinbase_positions.rb
@@ -416,7 +416,7 @@ module Trading
         end
       end
 
-      Position.create!(
+      position = Position.create!(
         product_id: product_id,
         side: position_side,
         size: size,
@@ -428,6 +428,20 @@ module Trading
         stop_loss: stop_loss,
         trailing_stop_enabled: ActiveModel::Type::Boolean.new.cast(ENV.fetch("TRAILING_STOP_ENABLED", "false")),
         trailing_stop_state: {}
+      )
+
+      persist_order(
+        position: position,
+        contract_id: product_id,
+        side: SideNormalizer.order(side) || "buy",
+        order_type: "market",
+        quantity: size,
+        target_price: entry_price,
+        fill_price: entry_price,
+        status: "filled",
+        placed_at: Time.current,
+        filled_at: Time.current,
+        coinbase_order_id: order_result&.dig("order_id") || order_result&.dig("success_response", "order_id")
       )
 
       @logger.info("Created local position record for #{product_id}: #{position_side} #{size} at #{entry_price}")
@@ -442,6 +456,20 @@ module Trading
       return unless position
 
       close_price ||= position.entry_price
+
+      persist_order(
+        position: position,
+        contract_id: product_id,
+        side: position.long? ? "sell" : "buy",
+        order_type: "market",
+        quantity: size || position.size,
+        target_price: close_price,
+        fill_price: close_price,
+        status: "filled",
+        placed_at: Time.current,
+        filled_at: Time.current,
+        coinbase_order_id: order_result&.dig("order_id") || order_result&.dig("success_response", "order_id")
+      )
 
       # Close the position
       position.close_position!(close_price)
@@ -460,6 +488,20 @@ module Trading
       total_size = position.size + additional_size.to_f
       new_entry_price = ((position.size * position.entry_price) + (additional_size.to_f * additional_price)) / total_size
 
+      persist_order(
+        position: position,
+        contract_id: product_id,
+        side: position.long? ? "buy" : "sell",
+        order_type: "market",
+        quantity: additional_size,
+        target_price: additional_price,
+        fill_price: additional_price,
+        status: "filled",
+        placed_at: Time.current,
+        filled_at: Time.current,
+        coinbase_order_id: order_result&.dig("order_id") || order_result&.dig("success_response", "order_id")
+      )
+
       # Update the position
       position.update!(
         size: total_size,
@@ -470,6 +512,25 @@ module Trading
     rescue => e
       @logger.error("Failed to update local position record for increase: #{e.message}")
       # Don't fail the main operation if local record update fails
+    end
+
+    def persist_order(position:, contract_id:, side:, order_type:, quantity:, status:,
+      target_price: nil, fill_price: nil, placed_at: nil, filled_at: nil, coinbase_order_id: nil)
+      Order.create!(
+        position: position,
+        contract_id: contract_id,
+        side: side.to_s.downcase,
+        order_type: order_type,
+        quantity: quantity,
+        target_price: target_price,
+        fill_price: fill_price,
+        status: status,
+        placed_at: placed_at,
+        filled_at: filled_at,
+        coinbase_order_id: coinbase_order_id
+      )
+    rescue => e
+      @logger.error("Failed to persist Order record: #{e.message}")
     end
 
     # --- Auth helpers (Advanced Trade style signing) ---

--- a/db/migrate/20260604152504_create_orders.rb
+++ b/db/migrate/20260604152504_create_orders.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateOrders < ActiveRecord::Migration[8.0]
+  def change
+    create_table :orders do |t|
+      t.references :position, null: true, foreign_key: true
+      t.string :coinbase_order_id
+      t.string :contract_id, null: false
+      t.string :side, null: false
+      t.string :order_type, null: false, default: "market"
+      t.decimal :target_price, precision: 20, scale: 8
+      t.decimal :fill_price, precision: 20, scale: 8
+      t.decimal :quantity, null: false, precision: 20, scale: 8
+      t.string :status, null: false, default: "pending"
+      t.datetime :placed_at
+      t.datetime :filled_at
+
+      t.timestamps
+    end
+
+    add_index :orders, :coinbase_order_id, unique: true, where: "coinbase_order_id IS NOT NULL"
+    add_index :orders, :status
+    add_index :orders, :contract_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,6 +147,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_181941) do
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
+  create_table "orders", force: :cascade do |t|
+    t.string "coinbase_order_id"
+    t.string "contract_id", null: false
+    t.datetime "created_at", null: false
+    t.decimal "fill_price", precision: 20, scale: 8
+    t.datetime "filled_at"
+    t.string "order_type", default: "market", null: false
+    t.datetime "placed_at"
+    t.bigint "position_id"
+    t.decimal "quantity", precision: 20, scale: 8, null: false
+    t.string "side", null: false
+    t.string "status", default: "pending", null: false
+    t.decimal "target_price", precision: 20, scale: 8
+    t.datetime "updated_at", null: false
+    t.index ["coinbase_order_id"], name: "index_orders_on_coinbase_order_id", unique: true, where: "(coinbase_order_id IS NOT NULL)"
+    t.index ["contract_id"], name: "index_orders_on_contract_id"
+    t.index ["position_id"], name: "index_orders_on_position_id"
+    t.index ["status"], name: "index_orders_on_status"
+  end
+
   create_table "positions", force: :cascade do |t|
     t.datetime "close_time"
     t.datetime "created_at", null: false
@@ -266,4 +286,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_181941) do
   end
 
   add_foreign_key "chat_messages", "chat_sessions"
+  add_foreign_key "orders", "positions"
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :order do
+    association :position
+    contract_id { "BIT-29AUG25-CDE" }
+    side { "buy" }
+    order_type { "market" }
+    quantity { 1.0 }
+    status { "pending" }
+    placed_at { Time.current }
+
+    trait :filled do
+      status { "filled" }
+      fill_price { 50_100.0 }
+      filled_at { Time.current }
+    end
+
+    trait :with_target do
+      target_price { 50_000.0 }
+    end
+
+    trait :limit do
+      order_type { "limit" }
+      target_price { 50_000.0 }
+    end
+
+    trait :sell do
+      side { "sell" }
+    end
+
+    trait :cancelled do
+      status { "cancelled" }
+    end
+
+    trait :orphaned do
+      position { nil }
+    end
+
+    trait :with_coinbase_id do
+      coinbase_order_id { SecureRandom.uuid }
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order, type: :model do
+  let(:position) { create(:position) }
+
+  let(:valid_attrs) do
+    {
+      position: position,
+      contract_id: "BIT-29AUG25-CDE",
+      side: "buy",
+      order_type: "market",
+      quantity: 1.0,
+      status: "pending",
+      placed_at: Time.current
+    }
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(described_class.new(valid_attrs)).to be_valid
+    end
+
+    it "requires contract_id" do
+      order = described_class.new(valid_attrs.merge(contract_id: nil))
+      expect(order).not_to be_valid
+      expect(order.errors[:contract_id]).to be_present
+    end
+
+    it "requires side" do
+      order = described_class.new(valid_attrs.merge(side: nil))
+      expect(order).not_to be_valid
+    end
+
+    it "requires order_type" do
+      order = described_class.new(valid_attrs.merge(order_type: nil))
+      expect(order).not_to be_valid
+    end
+
+    it "requires quantity" do
+      order = described_class.new(valid_attrs.merge(quantity: nil))
+      expect(order).not_to be_valid
+    end
+
+    it "requires quantity > 0" do
+      order = described_class.new(valid_attrs.merge(quantity: 0))
+      expect(order).not_to be_valid
+    end
+
+    it "requires status" do
+      order = described_class.new(valid_attrs.merge(status: nil))
+      expect(order).not_to be_valid
+    end
+
+    it "rejects invalid side" do
+      order = described_class.new(valid_attrs.merge(side: "long"))
+      expect(order).not_to be_valid
+    end
+
+    it "rejects invalid order_type" do
+      order = described_class.new(valid_attrs.merge(order_type: "stop"))
+      expect(order).not_to be_valid
+    end
+
+    it "rejects invalid status" do
+      order = described_class.new(valid_attrs.merge(status: "unknown"))
+      expect(order).not_to be_valid
+    end
+
+    it "enforces unique coinbase_order_id" do
+      uuid = SecureRandom.uuid
+      create(:order, valid_attrs.merge(coinbase_order_id: uuid))
+      dup = described_class.new(valid_attrs.merge(coinbase_order_id: uuid))
+      expect(dup).not_to be_valid
+    end
+
+    it "allows nil coinbase_order_id (multiple orders without exchange id)" do
+      create(:order, valid_attrs.merge(coinbase_order_id: nil))
+      second = described_class.new(valid_attrs.merge(coinbase_order_id: nil))
+      expect(second).to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "belongs_to position optionally" do
+      order = described_class.new(valid_attrs.merge(position: nil))
+      expect(order).to be_valid
+    end
+
+    it "links back from position.orders" do
+      order = create(:order, valid_attrs)
+      expect(position.orders).to include(order)
+    end
+
+    it "nullifies position_id when position is destroyed" do
+      order = create(:order, valid_attrs)
+      position.destroy!
+      expect(order.reload.position_id).to be_nil
+    end
+  end
+
+  describe "scopes" do
+    let!(:filled_order) { create(:order, valid_attrs.merge(status: "filled", fill_price: 50_100.0, filled_at: Time.current)) }
+    let!(:pending_order) { create(:order, valid_attrs) }
+    let!(:sell_order) { create(:order, valid_attrs.merge(side: "sell")) }
+
+    it ".filled returns filled orders" do
+      expect(described_class.filled).to include(filled_order)
+      expect(described_class.filled).not_to include(pending_order)
+    end
+
+    it ".pending returns pending orders" do
+      expect(described_class.pending).to include(pending_order)
+      expect(described_class.pending).not_to include(filled_order)
+    end
+
+    it ".closing returns sell orders" do
+      expect(described_class.closing).to include(sell_order)
+      expect(described_class.closing).not_to include(pending_order)
+    end
+  end
+
+  describe "#filled?" do
+    it "returns true when status is filled" do
+      order = described_class.new(valid_attrs.merge(status: "filled"))
+      expect(order.filled?).to be true
+    end
+
+    it "returns false when status is pending" do
+      expect(described_class.new(valid_attrs).filled?).to be false
+    end
+  end
+
+  describe "#slippage" do
+    it "returns nil when target_price is nil" do
+      order = described_class.new(valid_attrs.merge(fill_price: 50_100.0, target_price: nil))
+      expect(order.slippage).to be_nil
+    end
+
+    it "returns fill_price minus target_price" do
+      order = described_class.new(valid_attrs.merge(target_price: 50_000.0, fill_price: 50_100.0))
+      expect(order.slippage).to eq(100.0)
+    end
+
+    it "returns negative slippage for favorable fills" do
+      order = described_class.new(valid_attrs.merge(target_price: 50_000.0, fill_price: 49_900.0))
+      expect(order.slippage).to eq(-100.0)
+    end
+  end
+
+  describe "#slippage_bps" do
+    it "returns nil when target_price is nil" do
+      order = described_class.new(valid_attrs.merge(fill_price: 50_100.0, target_price: nil))
+      expect(order.slippage_bps).to be_nil
+    end
+
+    it "returns slippage in basis points" do
+      order = described_class.new(valid_attrs.merge(target_price: 50_000.0, fill_price: 50_100.0))
+      expect(order.slippage_bps).to be_within(0.01).of(20.0)
+    end
+  end
+end

--- a/spec/services/coinbase_positions_spec.rb
+++ b/spec/services/coinbase_positions_spec.rb
@@ -482,4 +482,78 @@ RSpec.describe Trading::CoinbasePositions, type: :service do
       expect(res["message"]).to match(/No open position/)
     end
   end
+
+  describe "Order persistence" do
+    let(:product_id) { "BIT-29AUG25-CDE" }
+
+    before do
+      allow(service).to receive(:get_current_market_price).and_return(50_000.0)
+      allow(TradingHalt).to receive(:assert_active!).and_return(true)
+    end
+
+    describe "#open_position persists an Order" do
+      it "creates an Order record linked to the new Position" do
+        mock_response = instance_double("Response", body: {"success" => true, "order_id" => "open-abc"}.to_json)
+        conn = service.instance_variable_get(:@conn)
+        allow(conn).to receive(:post).and_return(mock_response)
+
+        expect {
+          service.open_position(product_id: product_id, side: :buy, size: "1", day_trading: true)
+        }.to change(Order, :count).by(1)
+
+        order = Order.last
+        expect(order.contract_id).to eq(product_id)
+        expect(order.side).to eq("buy")
+        expect(order.status).to eq("filled")
+        expect(order.coinbase_order_id).to eq("open-abc")
+        expect(order.position).to be_present
+      end
+    end
+
+    describe "#close_position persists an Order" do
+      let!(:open_position) { create(:position, product_id: product_id, side: "LONG", status: "OPEN") }
+
+      it "creates a closing Order record" do
+        allow(service).to receive(:list_open_positions).and_return([
+          {"product_id" => product_id, "number_of_contracts" => "1", "side" => "LONG"}
+        ])
+        mock_response = instance_double("Response", body: {"success" => true, "order_id" => "close-xyz"}.to_json)
+        conn = service.instance_variable_get(:@conn)
+        allow(conn).to receive(:post).and_return(mock_response)
+
+        expect {
+          service.close_position(product_id: product_id, size: "1")
+        }.to change(Order, :count).by(1)
+
+        order = Order.last
+        expect(order.side).to eq("sell")
+        expect(order.status).to eq("filled")
+        expect(order.coinbase_order_id).to eq("close-xyz")
+        expect(order.position).to eq(open_position)
+      end
+    end
+
+    describe "#increase_position persists an Order" do
+      let!(:open_position) { create(:position, product_id: product_id, side: "LONG", status: "OPEN") }
+
+      it "creates an increase Order record" do
+        allow(service).to receive(:list_open_positions).and_return([
+          {"product_id" => product_id, "number_of_contracts" => "1", "side" => "LONG"}
+        ])
+        mock_response = instance_double("Response", body: {"success" => true, "order_id" => "increase-99"}.to_json)
+        conn = service.instance_variable_get(:@conn)
+        allow(conn).to receive(:post).and_return(mock_response)
+
+        expect {
+          service.increase_position(product_id: product_id, size: "1")
+        }.to change(Order, :count).by(1)
+
+        order = Order.last
+        expect(order.side).to eq("buy")
+        expect(order.status).to eq("filled")
+        expect(order.coinbase_order_id).to eq("increase-99")
+        expect(order.position).to eq(open_position)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #196

## What
Implements `Order` as a first-class domain record per ADR 0001, so every Coinbase order placement has a corresponding persisted `Order` row.

## Changes
- `CreateOrders` migration — `orders` table with `position_id`, `coinbase_order_id`, `contract_id`, `side`, `order_type`, `target_price`, `fill_price`, `quantity`, `status`, `placed_at`, `filled_at`
- `Order` model — validations, scopes (`.filled`, `.pending`, `.closing`), `#slippage` / `#slippage_bps` helpers
- `Position` — adds `has_many :orders, dependent: :nullify`
- `CoinbasePositions` — wires `persist_order` helper into `open_position`, `close_position`, `increase_position`

## Test plan
- [ ] `spec/models/order_spec.rb` — 25 examples covering validations, associations, scopes, slippage
- [ ] `spec/services/coinbase_positions_spec.rb` — 3 new integration examples for order persistence on open/close/increase
- [ ] Pre-existing failures (candle scopes, coinbase_rest, futuresbot_launcher) are unrelated to this branch