### PR TITLE
fix(ci): use --first-is-1 to isolate parallel worker DBs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,8 @@ jobs:
           done
           echo "PostgreSQL is ready!"
 
-          # Create worker DBs manually (parallel_tests is dev-only gem, rake tasks unavailable in CI)
-          # Worker 1 uses the default DB; worker 2 gets a numbered suffix DB
-          bin/rails db:create db:migrate
+          # Create both numbered worker DBs (--first-is-1 means workers use suffix 1 and 2)
+          TEST_ENV_NUMBER=1 bin/rails db:create db:migrate
           TEST_ENV_NUMBER=2 bin/rails db:create db:migrate
           echo "Database setup complete"
 
@@ -261,12 +260,12 @@ jobs:
 
           # Verify database connectivity with real operations
           echo "=== VERIFYING REAL DATABASE OPERATIONS ==="
-          bin/rails runner "puts 'Database: ' + ActiveRecord::Base.connection.current_database"
-          bin/rails runner "puts 'Tables: ' + ActiveRecord::Base.connection.tables.join(', ')"
+          TEST_ENV_NUMBER=1 bin/rails runner "puts 'Database: ' + ActiveRecord::Base.connection.current_database"
+          TEST_ENV_NUMBER=1 bin/rails runner "puts 'Tables: ' + ActiveRecord::Base.connection.tables.join(', ')"
 
           # Test real database operations
           echo "=== TESTING REAL DATABASE OPERATIONS ==="
-          bin/rails runner "
+          TEST_ENV_NUMBER=1 bin/rails runner "
             begin
               # Create a test record
               test_pos = Position.create!(

--- a/bin/parallel_rspec
+++ b/bin/parallel_rspec
@@ -58,5 +58,5 @@ flags = parallel_flags_from_config(config_path)
 # Reduces allocator churn when many Ruby processes share one host (common parallel win).
 ENV["MALLOC_ARENA_MAX"] ||= "2"
 
-cmd = ["bundle", "exec", "parallel_rspec", *flags, *ARGV]
+cmd = ["bundle", "exec", "parallel_rspec", "--first-is-1", *flags, *ARGV]
 exec(*cmd)


### PR DESCRIPTION
## Summary

- Without `--first-is-1`, worker 1 uses the unnumbered default DB (shared with `bin/rails runner` verification steps), causing count-based specs to see unexpected rows
- With `--first-is-1`, both workers get numbered DBs (suffix 1 and 2), fully isolated; CI verification steps explicitly set `TEST_ENV_NUMBER=1`

## Test plan

- [ ] CI passes with both parallel workers green
- [ ] No count-based spec flakiness from shared DB