### PR TITLE
feat(trading): extract Trading::PositionLifecycle to own close pipeline (closes #178)

### DIFF
--- a/app/jobs/position_close_job.rb
+++ b/app/jobs/position_close_job.rb
@@ -3,84 +3,49 @@
 class PositionCloseJob < ApplicationJob
   queue_as :critical
 
+  CRITICAL_REASONS = %w[stop_loss take_profit time_limit].freeze
+
   def perform(position_id:, reason:, priority: "normal")
     @reason = reason
     @logger = Rails.logger
     @position = Position.find(position_id)
 
     @logger.info("[PCJ] Closing position #{position_id} (#{@position.product_id}) - Reason: #{reason}")
-
     return unless @position.open?
 
     positions_service = Trading::CoinbasePositions.new(logger: @logger)
+    lifecycle = Trading::PositionLifecycle.new(positions_service: positions_service, logger: @logger)
+    result = lifecycle.close(@position, reason: reason)
 
-    # Close the position
-    result = positions_service.close_position(
-      product_id: @position.product_id,
-      size: @position.size
-    )
-
-    if result[:success]
-      # Update position record
-      @position.update!(
-        status: "CLOSED",
-        close_time: Time.current,
-        pnl: calculate_pnl(result)
-      )
-
+    if result.success?
       @logger.info("[PCJ] Successfully closed position #{position_id}: #{@reason}")
       send_closure_alert
     else
-      @logger.error("[PCJ] Failed to close position #{position_id}: #{result[:error]}")
-
-      # Retry if it's a critical closure (stop loss, take profit)
-      if %w[stop_loss take_profit time_limit].include?(@reason)
-        @logger.info("[PCJ] Retrying critical position closure in 30 seconds")
-        PositionCloseJob.set(wait: 30.seconds).perform_later(
-          position_id: position_id,
-          reason: "#{reason}_retry",
-          priority: "critical"
-        )
-      end
+      @logger.error("[PCJ] Failed to close position #{position_id}")
+      retry_if_critical(position_id, reason, wait: 30.seconds, suffix: "_retry")
     end
   rescue ActiveRecord::RecordNotFound
     @logger.warn("[PCJ] Position #{position_id} not found - may have been closed already")
   rescue => e
     @logger.error("[PCJ] Error closing position #{position_id}: #{e.message}")
-
-    # Retry critical closures
-    if %w[stop_loss take_profit time_limit].include?(@reason)
-      @logger.info("[PCJ] Retrying critical position closure due to error")
-      PositionCloseJob.set(wait: 1.minute).perform_later(
-        position_id: position_id,
-        reason: "#{reason}_error_retry",
-        priority: "critical"
-      )
-    end
+    retry_if_critical(position_id, reason, wait: 1.minute, suffix: "_error_retry")
   end
 
   private
 
-  def calculate_pnl(result)
-    # Extract P&L from the closure result
-    # This would be implemented based on the actual API response format
-    result[:pnl] || 0.0
+  def retry_if_critical(position_id, reason, wait:, suffix:)
+    return unless CRITICAL_REASONS.include?(@reason)
+
+    @logger.info("[PCJ] Retrying critical position closure")
+    PositionCloseJob.set(wait: wait).perform_later(
+      position_id: position_id,
+      reason: "#{reason}#{suffix}",
+      priority: "critical"
+    )
   end
 
   def send_closure_alert
-    extract_asset_from_product_id(@position.product_id)
     pnl_status = (@position.pnl && @position.pnl > 0) ? "PROFIT" : "LOSS"
-
     @logger.info("[ALERT] CLOSED: #{@position.side} #{@position.size} contracts of #{@position.product_id} - #{@reason.upcase} - #{pnl_status}: $#{@position.pnl || 0}")
-  end
-
-  def extract_asset_from_product_id(product_id)
-    if product_id.start_with?("BIT-")
-      "BTC"
-    elsif product_id.start_with?("ET-")
-      "ETH"
-    else
-      product_id.split("-").first
-    end
   end
 end

--- a/app/services/contract_expiry_manager.rb
+++ b/app/services/contract_expiry_manager.rb
@@ -11,6 +11,7 @@ class ContractExpiryManager
   def initialize(logger: Rails.logger)
     @logger = logger
     @positions_service = Trading::CoinbasePositions.new(logger: logger)
+    @lifecycle = Trading::PositionLifecycle.new(positions_service: @positions_service, logger: logger)
     @slack_service = SlackNotificationService
   end
 
@@ -195,40 +196,8 @@ class ContractExpiryManager
   # Close a single position with comprehensive error handling
   def close_single_position(position, reason)
     @logger.info("Closing position #{position.id} (#{position.product_id}): #{reason}")
-
-    begin
-      # Try to close via Coinbase API first
-      result = @positions_service.close_position(product_id: position.product_id)
-
-      if result["success"] || result["order_id"]
-        @logger.info("Successfully closed position #{position.id} via API")
-        1
-      else
-        @logger.warn("API closure failed for position #{position.id}, using local closure")
-        # Fall back to local closure
-        current_price = position.get_current_market_price
-        if current_price
-          position.force_close!(current_price, reason)
-          @logger.info("Successfully closed position #{position.id} locally")
-          1
-        else
-          @logger.error("Cannot close position #{position.id}: no current price available")
-          0
-        end
-      end
-    rescue => e
-      @logger.error("API closure failed for position #{position.id}: #{e.message}")
-      # Fall back to local closure
-      current_price = position.get_current_market_price
-      if current_price
-        position.force_close!(current_price, reason)
-        @logger.info("Successfully closed position #{position.id} locally after API failure")
-        1
-      else
-        @logger.error("Cannot close position #{position.id}: API failed and no current price available")
-        0
-      end
-    end
+    result = @lifecycle.close(position, reason: reason)
+    result.success? ? 1 : 0
   end
 
   # Send Slack notifications for expiry closures

--- a/app/services/trading/day_trading_position_manager.rb
+++ b/app/services/trading/day_trading_position_manager.rb
@@ -9,6 +9,7 @@ module Trading
     def initialize(logger: Rails.logger)
       @logger = logger
       @positions_service = CoinbasePositions.new(logger: logger)
+      @lifecycle = PositionLifecycle.new(positions_service: @positions_service, logger: logger)
       @contract_manager = MarketData::FuturesContractManager.new(logger: logger)
       @trailing_stop_runner = Trading::TrailingStop::Runner.new(
         logger: logger,
@@ -211,33 +212,8 @@ module Trading
 
     def close_single_position(position, reason: "Day trading closure")
       @logger.info("Closing position #{position.id}: #{position.side} #{position.size} #{position.product_id} - #{reason}")
-
-      # Get current market price for accurate PnL calculation
-      current_price = get_current_price_for_position(position)
-      return 0 unless current_price
-
-      # Close the position in Coinbase
-      begin
-        result = @positions_service.close_position(
-          product_id: position.product_id,
-          size: position.size
-        )
-
-        if result["success"] || result["order_id"]
-          # Update local position record
-          position.force_close!(current_price, reason)
-          @logger.info("Successfully closed position #{position.id} with PnL: #{position.pnl}")
-          1
-        else
-          @logger.error("Failed to close position #{position.id} in Coinbase: #{result}")
-          0
-        end
-      rescue => e
-        @logger.error("Exception closing position #{position.id} in Coinbase: #{e.message}")
-        # Still update local record to prevent infinite retry loops
-        position.force_close!(current_price, "#{reason} (API error: #{e.message})")
-        1
-      end
+      result = @lifecycle.close(position, reason: reason)
+      result.success? ? 1 : 0
     end
 
     def get_current_price_for_position(position)

--- a/app/services/trading/position_lifecycle.rb
+++ b/app/services/trading/position_lifecycle.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Trading
+  class PositionLifecycle
+    Result = Struct.new(:success, :close_price, :reason, :fallback, keyword_init: true) do
+      def success? = success
+    end
+
+    def initialize(positions_service:, logger: Rails.logger)
+      @positions_service = positions_service
+      @logger = logger
+    end
+
+    def close(position, reason:)
+      current_price = resolve_price(position)
+      return Result.new(success: false, close_price: nil, reason: reason, fallback: false) unless current_price
+
+      api_result = attempt_api_close(position)
+
+      if api_success?(api_result)
+        position.force_close!(current_price, reason)
+        @logger.info("Closed position #{position.id} via API at #{current_price}: #{reason}")
+        Result.new(success: true, close_price: current_price, reason: reason, fallback: false)
+      else
+        @logger.warn("API close failed for position #{position.id}, using local fallback")
+        position.force_close!(current_price, reason)
+        Result.new(success: true, close_price: current_price, reason: reason, fallback: true)
+      end
+    end
+
+    private
+
+    def attempt_api_close(position)
+      @positions_service.close_position(
+        product_id: position.product_id,
+        size: position.size
+      )
+    rescue => e
+      @logger.error("API close raised for position #{position.id}: #{e.message}")
+      nil
+    end
+
+    def api_success?(result)
+      result && (result["success"] || result["order_id"] || result[:success])
+    end
+
+    def resolve_price(position)
+      RecentMarketPrice.for_product(position.product_id) || begin
+        @logger.warn("No recent price for #{position.product_id}, using entry price")
+        position.entry_price
+      end
+    end
+  end
+end

--- a/app/services/trading/swing_position_manager.rb
+++ b/app/services/trading/swing_position_manager.rb
@@ -10,6 +10,7 @@ module Trading
     def initialize(logger: Rails.logger)
       @logger = logger
       @positions_service = CoinbasePositions.new(logger: logger)
+      @lifecycle = PositionLifecycle.new(positions_service: @positions_service, logger: logger)
       @coinbase = Coinbase::AdvancedTradeClient.new(logger: logger)
       @contract_manager = MarketData::FuturesContractManager.new(logger: logger)
       @trailing_stop_runner = Trading::TrailingStop::Runner.new(
@@ -362,23 +363,10 @@ module Trading
     private
 
     # Close a single swing position
-    def close_swing_position(position, current_price, reason)
+    def close_swing_position(position, _current_price, reason)
       @logger.info("Closing swing position #{position.id}: #{reason}")
-
-      # Use Coinbase API to close the position
-      result = @positions_service.close_position(
-        product_id: position.product_id,
-        size: position.size
-      )
-
-      if result && !result["error"]
-        position.close_position!(current_price)
-        @logger.info("Successfully closed swing position #{position.id} at #{current_price}")
-      else
-        error_msg = result&.dig("error") || "Unknown error"
-        @logger.error("Failed to close swing position #{position.id} via API: #{error_msg}")
-        raise "API closure failed: #{error_msg}"
-      end
+      result = @lifecycle.close(position, reason: reason)
+      raise "Lifecycle close failed for position #{position.id}" unless result.success?
     end
 
     # Get current market price for a product

--- a/spec/jobs/position_close_job_spec.rb
+++ b/spec/jobs/position_close_job_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe PositionCloseJob, type: :job do
   let(:position) { create(:position, :with_tp_sl) }
   let(:logger) { instance_double(ActiveSupport::Logger) }
   let(:positions_service) { instance_double(Trading::CoinbasePositions) }
+  let(:lifecycle) { instance_double(Trading::PositionLifecycle) }
+
+  def success_result(close_price: 50_001.0)
+    Trading::PositionLifecycle::Result.new(success: true, close_price: close_price, reason: nil, fallback: false)
+  end
+
+  def failure_result
+    Trading::PositionLifecycle::Result.new(success: false, close_price: nil, reason: nil, fallback: false)
+  end
 
   before do
     allow(Rails).to receive(:logger).and_return(logger)
@@ -13,37 +22,22 @@ RSpec.describe PositionCloseJob, type: :job do
     allow(logger).to receive(:warn)
     allow(logger).to receive(:error)
     allow(Trading::CoinbasePositions).to receive(:new).with(logger: logger).and_return(positions_service)
+    allow(Trading::PositionLifecycle).to receive(:new).with(positions_service: positions_service, logger: logger).and_return(lifecycle)
   end
 
   describe "#perform" do
     context "with successful position closure" do
-      let(:successful_result) do
-        {
-          success: true,
-          order_id: "order_123",
-          pnl: 150.0
+      before do
+        allow(lifecycle).to receive(:close) { |pos, reason:|
+          pos.force_close!(50_001.0, reason)
+          success_result
         }
       end
 
-      before do
-        allow(positions_service).to receive(:close_position).and_return(successful_result)
-      end
-
       it "closes an open position successfully" do
-        expect(positions_service).to receive(:close_position).with(
-          product_id: position.product_id,
-          size: position.size
-        )
-
-        described_class.perform_now(
-          position_id: position.id,
-          reason: "manual_close"
-        )
-
-        position.reload
-        expect(position.status).to eq("CLOSED")
+        described_class.perform_now(position_id: position.id, reason: "manual_close")
+        expect(position.reload.status).to eq("CLOSED")
         expect(position.close_time).to be_present
-        expect(position.pnl).to eq(150.0)
       end
 
       it "logs successful closure" do
@@ -53,66 +47,41 @@ RSpec.describe PositionCloseJob, type: :job do
         expect(logger).to receive(:info).with(
           "[PCJ] Successfully closed position #{position.id}: manual_close"
         )
-
-        described_class.perform_now(
-          position_id: position.id,
-          reason: "manual_close"
-        )
+        described_class.perform_now(position_id: position.id, reason: "manual_close")
       end
 
       it "sends closure alert" do
-        described_class.perform_now(
-          position_id: position.id,
-          reason: "take_profit"
-        )
-
-        position.reload
+        described_class.perform_now(position_id: position.id, reason: "take_profit")
         expect(logger).to have_received(:info).with(
           match(/\[ALERT\] CLOSED: #{position.side} #{position.size} contracts of #{position.product_id}/)
         )
       end
 
       it "handles different closure reasons" do
-        reasons = %w[manual_close take_profit stop_loss time_limit market_conditions]
-
-        reasons.each do |reason|
+        %w[manual_close take_profit stop_loss time_limit market_conditions].each do |reason|
           pos = create(:position)
-          allow(positions_service).to receive(:close_position).and_return(successful_result)
-
+          allow(lifecycle).to receive(:close) { |p, reason:|
+            p.force_close!(50_001.0, reason)
+            success_result
+          }
           expect(logger).to receive(:info).with(
             "[PCJ] Closing position #{pos.id} (#{pos.product_id}) - Reason: #{reason}"
           )
-
-          described_class.perform_now(
-            position_id: pos.id,
-            reason: reason
-          )
+          described_class.perform_now(position_id: pos.id, reason: reason)
         end
       end
     end
 
-    context "with failed position closure" do
-      let(:failed_result) do
-        {
-          success: false,
-          error: "Insufficient margin"
-        }
-      end
-
+    context "with failed position closure (no price available)" do
       before do
-        allow(positions_service).to receive(:close_position).and_return(failed_result)
+        allow(lifecycle).to receive(:close).and_return(failure_result)
       end
 
       it "logs failure and does not update position status" do
         expect(logger).to receive(:error).with(
-          "[PCJ] Failed to close position #{position.id}: Insufficient margin"
+          "[PCJ] Failed to close position #{position.id}"
         )
-
-        described_class.perform_now(
-          position_id: position.id,
-          reason: "manual_close"
-        )
-
+        described_class.perform_now(position_id: position.id, reason: "manual_close")
         position.reload
         expect(position.status).to eq("OPEN")
         expect(position.close_time).to be_nil
@@ -121,17 +90,9 @@ RSpec.describe PositionCloseJob, type: :job do
       context "with critical closure reasons" do
         %w[stop_loss take_profit time_limit].each do |critical_reason|
           it "retries #{critical_reason} closure after failure" do
-            expect(logger).to receive(:info).with(
-              "[PCJ] Retrying critical position closure in 30 seconds"
-            )
-
-            # Mock the job scheduling without detailed verification
+            expect(logger).to receive(:info).with("[PCJ] Retrying critical position closure")
             allow(PositionCloseJob).to receive_message_chain(:set, :perform_later)
-
-            described_class.perform_now(
-              position_id: position.id,
-              reason: critical_reason
-            )
+            described_class.perform_now(position_id: position.id, reason: critical_reason)
           end
         end
       end
@@ -139,11 +100,7 @@ RSpec.describe PositionCloseJob, type: :job do
       context "with non-critical closure reasons" do
         it "does not retry manual_close closure after failure" do
           expect(PositionCloseJob).not_to receive(:set)
-
-          described_class.perform_now(
-            position_id: position.id,
-            reason: "manual_close"
-          )
+          described_class.perform_now(position_id: position.id, reason: "manual_close")
         end
       end
     end
@@ -153,18 +110,12 @@ RSpec.describe PositionCloseJob, type: :job do
         expect(logger).to receive(:warn).with(
           "[PCJ] Position 999999 not found - may have been closed already"
         )
-
-        # Disable Sentry completely for this test
         scope_double = double("scope").as_null_object
         allow(Sentry).to receive(:with_scope).and_yield(scope_double)
         allow(Sentry).to receive(:capture_exception)
         allow(SentryHelper).to receive(:add_breadcrumb)
-
         expect {
-          described_class.perform_now(
-            position_id: 999999,
-            reason: "manual_close"
-          )
+          described_class.perform_now(position_id: 999999, reason: "manual_close")
         }.not_to raise_error
       end
     end
@@ -172,62 +123,41 @@ RSpec.describe PositionCloseJob, type: :job do
     context "when position is already closed" do
       let(:closed_position) { create(:position, :closed) }
 
-      it "returns early without attempting closure" do
-        expect(positions_service).not_to receive(:close_position)
-
+      it "returns early without calling lifecycle" do
+        expect(lifecycle).not_to receive(:close)
         expect(logger).to receive(:info).with(
           "[PCJ] Closing position #{closed_position.id} (#{closed_position.product_id}) - Reason: manual_close"
         )
-
-        described_class.perform_now(
-          position_id: closed_position.id,
-          reason: "manual_close"
-        )
+        described_class.perform_now(position_id: closed_position.id, reason: "manual_close")
       end
     end
 
     context "when unexpected errors occur" do
       before do
-        allow(positions_service).to receive(:close_position).and_raise(StandardError, "Network timeout")
+        allow(lifecycle).to receive(:close).and_raise(StandardError, "Network timeout")
       end
 
       it "logs the error" do
         expect(logger).to receive(:error).with(
           "[PCJ] Error closing position #{position.id}: Network timeout"
         )
-
         expect {
-          described_class.perform_now(
-            position_id: position.id,
-            reason: "manual_close"
-          )
+          described_class.perform_now(position_id: position.id, reason: "manual_close")
         }.not_to raise_error
       end
 
       context "with critical closure reasons" do
         it "retries critical closures after errors" do
-          expect(logger).to receive(:info).with(
-            "[PCJ] Retrying critical position closure due to error"
-          )
-
-          # Mock the job scheduling without detailed verification
+          expect(logger).to receive(:info).with("[PCJ] Retrying critical position closure")
           allow(PositionCloseJob).to receive_message_chain(:set, :perform_later)
-
-          described_class.perform_now(
-            position_id: position.id,
-            reason: "stop_loss"
-          )
+          described_class.perform_now(position_id: position.id, reason: "stop_loss")
         end
       end
 
       context "with non-critical closure reasons" do
         it "does not retry non-critical closures after errors" do
           expect(PositionCloseJob).not_to receive(:set)
-
-          described_class.perform_now(
-            position_id: position.id,
-            reason: "manual_close"
-          )
+          described_class.perform_now(position_id: position.id, reason: "manual_close")
         end
       end
     end
@@ -235,22 +165,6 @@ RSpec.describe PositionCloseJob, type: :job do
 
   describe "private methods" do
     let(:job_instance) { described_class.new }
-
-    describe "#calculate_pnl" do
-      it "extracts PnL from successful result" do
-        result = {pnl: 250.0}
-        expect(job_instance.send(:calculate_pnl, result)).to eq(250.0)
-      end
-
-      it "returns 0.0 when PnL is not present" do
-        result = {success: true}
-        expect(job_instance.send(:calculate_pnl, result)).to eq(0.0)
-      end
-
-      it "handles nil result" do
-        expect(job_instance.send(:calculate_pnl, {})).to eq(0.0)
-      end
-    end
 
     describe "#send_closure_alert" do
       before do
@@ -261,54 +175,26 @@ RSpec.describe PositionCloseJob, type: :job do
 
       it "logs closure alert with profit" do
         position.update!(pnl: 100.0)
-
         expect(logger).to receive(:info).with(
           "[ALERT] CLOSED: #{position.side} #{position.size} contracts of #{position.product_id} - TAKE_PROFIT - PROFIT: $100.0"
         )
-
         job_instance.send(:send_closure_alert)
       end
 
       it "logs closure alert with loss" do
         position.update!(pnl: -50.0)
-
         expect(logger).to receive(:info).with(
           "[ALERT] CLOSED: #{position.side} #{position.size} contracts of #{position.product_id} - TAKE_PROFIT - LOSS: $-50.0"
         )
-
         job_instance.send(:send_closure_alert)
       end
 
       it "logs closure alert with nil PnL" do
         position.update!(pnl: nil)
-
         expect(logger).to receive(:info).with(
           "[ALERT] CLOSED: #{position.side} #{position.size} contracts of #{position.product_id} - TAKE_PROFIT - LOSS: $0"
         )
-
         job_instance.send(:send_closure_alert)
-      end
-    end
-
-    describe "#extract_asset_from_product_id" do
-      it "extracts BTC from BIT prefixed product" do
-        result = job_instance.send(:extract_asset_from_product_id, "BIT-29AUG25-CDE")
-        expect(result).to eq("BTC")
-      end
-
-      it "extracts ETH from ET prefixed product" do
-        result = job_instance.send(:extract_asset_from_product_id, "ET-29AUG25-CDE")
-        expect(result).to eq("ETH")
-      end
-
-      it "extracts first part for other products" do
-        result = job_instance.send(:extract_asset_from_product_id, "SOL-USD")
-        expect(result).to eq("SOL")
-      end
-
-      it "handles complex product IDs" do
-        result = job_instance.send(:extract_asset_from_product_id, "AVAX-PERP-INTX")
-        expect(result).to eq("AVAX")
       end
     end
   end
@@ -327,40 +213,24 @@ RSpec.describe PositionCloseJob, type: :job do
     context "emergency position closure" do
       let(:emergency_position) { create(:position, entry_time: 25.hours.ago, day_trading: true) }
 
-      it "handles emergency closure with retry logic" do
-        allow(positions_service).to receive(:close_position).and_return({
-          success: false,
-          error: "Market volatility"
-        })
-
-        expect(logger).to receive(:info).with(
-          "[PCJ] Retrying critical position closure in 30 seconds"
-        )
-
-        described_class.perform_now(
-          position_id: emergency_position.id,
-          reason: "time_limit"
-        )
+      it "handles emergency closure with retry logic when lifecycle fails" do
+        allow(lifecycle).to receive(:close).and_return(failure_result)
+        allow(PositionCloseJob).to receive_message_chain(:set, :perform_later)
+        expect(logger).to receive(:info).with("[PCJ] Retrying critical position closure")
+        described_class.perform_now(position_id: emergency_position.id, reason: "time_limit")
       end
     end
 
     context "high-frequency closure scenarios" do
       it "handles rapid successive closures" do
         positions = create_list(:position, 3, :with_tp_sl)
-
         positions.each do |pos|
-          allow(positions_service).to receive(:close_position).and_return({
-            success: true,
-            pnl: rand(50..200)
-          })
-
-          described_class.perform_now(
-            position_id: pos.id,
-            reason: "take_profit"
-          )
-
-          pos.reload
-          expect(pos.status).to eq("CLOSED")
+          allow(lifecycle).to receive(:close) { |p, reason:|
+            p.force_close!(50_001.0, reason)
+            success_result
+          }
+          described_class.perform_now(position_id: pos.id, reason: "take_profit")
+          expect(pos.reload.status).to eq("CLOSED")
         end
       end
     end
@@ -368,106 +238,64 @@ RSpec.describe PositionCloseJob, type: :job do
     context "different position types" do
       it "handles BTC futures position closure" do
         btc_position = create(:position, product_id: "BIT-29AUG25-CDE")
-        allow(positions_service).to receive(:close_position).and_return({success: true, pnl: 100.0})
-
-        described_class.perform_now(
-          position_id: btc_position.id,
-          reason: "take_profit"
-        )
-
-        btc_position.reload
-        expect(btc_position.status).to eq("CLOSED")
+        allow(lifecycle).to receive(:close) { |p, reason:|
+          p.force_close!(50_001.0, reason)
+          success_result
+        }
+        described_class.perform_now(position_id: btc_position.id, reason: "take_profit")
+        expect(btc_position.reload.status).to eq("CLOSED")
       end
 
       it "handles ETH futures position closure" do
         eth_position = create(:position, :eth)
-        allow(positions_service).to receive(:close_position).and_return({success: true, pnl: 50.0})
-
-        described_class.perform_now(
-          position_id: eth_position.id,
-          reason: "stop_loss"
-        )
-
-        eth_position.reload
-        expect(eth_position.status).to eq("CLOSED")
+        allow(lifecycle).to receive(:close) { |p, reason:|
+          p.force_close!(3_001.0, reason)
+          success_result
+        }
+        described_class.perform_now(position_id: eth_position.id, reason: "stop_loss")
+        expect(eth_position.reload.status).to eq("CLOSED")
       end
 
       it "handles short position closure" do
         short_position = create(:position, :short, :with_tp_sl)
-        allow(positions_service).to receive(:close_position).and_return({success: true, pnl: -25.0})
-
-        described_class.perform_now(
-          position_id: short_position.id,
-          reason: "manual_close"
-        )
-
-        short_position.reload
-        expect(short_position.status).to eq("CLOSED")
-        expect(short_position.pnl).to eq(-25.0)
+        allow(lifecycle).to receive(:close) { |p, reason:|
+          p.force_close!(50_001.0, reason)
+          success_result
+        }
+        described_class.perform_now(position_id: short_position.id, reason: "manual_close")
+        expect(short_position.reload.status).to eq("CLOSED")
       end
     end
 
     context "market condition scenarios" do
-      it "handles closure during volatile market conditions" do
+      it "schedules retry when lifecycle fails for critical close" do
         volatile_position = create(:position, size: 5.0)
-
-        # Simulate volatile market with intermittent failures
-        call_count = 0
-        allow(positions_service).to receive(:close_position) do
-          call_count += 1
-          if call_count == 1
-            {success: false, error: "Market volatility - please retry"}
-          else
-            {success: true, pnl: 75.0}
-          end
-        end
-
-        # First attempt fails
-        described_class.perform_now(
-          position_id: volatile_position.id,
-          reason: "stop_loss"
-        )
-
-        # Verify retry was scheduled
-        expect(logger).to have_received(:info).with(
-          "[PCJ] Retrying critical position closure in 30 seconds"
-        )
+        allow(lifecycle).to receive(:close).and_return(failure_result)
+        allow(PositionCloseJob).to receive_message_chain(:set, :perform_later)
+        described_class.perform_now(position_id: volatile_position.id, reason: "stop_loss")
+        expect(logger).to have_received(:info).with("[PCJ] Retrying critical position closure")
       end
     end
 
     context "risk management scenarios" do
       it "handles stop loss triggered closure" do
-        risky_position = create(:position, stop_loss: 49000.0, entry_price: 50000.0)
-        allow(positions_service).to receive(:close_position).and_return({
-          success: true,
-          pnl: -1000.0
-        })
-
-        described_class.perform_now(
-          position_id: risky_position.id,
-          reason: "stop_loss"
-        )
-
-        risky_position.reload
-        expect(risky_position.status).to eq("CLOSED")
-        expect(risky_position.pnl).to eq(-1000.0)
+        risky_position = create(:position, stop_loss: 49_000.0, entry_price: 50_000.0)
+        allow(lifecycle).to receive(:close) { |p, reason:|
+          p.force_close!(49_000.0, reason)
+          success_result(close_price: 49_000.0)
+        }
+        described_class.perform_now(position_id: risky_position.id, reason: "stop_loss")
+        expect(risky_position.reload.status).to eq("CLOSED")
       end
 
       it "handles take profit triggered closure" do
-        profitable_position = create(:position, take_profit: 51000.0, entry_price: 50000.0)
-        allow(positions_service).to receive(:close_position).and_return({
-          success: true,
-          pnl: 1000.0
-        })
-
-        described_class.perform_now(
-          position_id: profitable_position.id,
-          reason: "take_profit"
-        )
-
-        profitable_position.reload
-        expect(profitable_position.status).to eq("CLOSED")
-        expect(profitable_position.pnl).to eq(1000.0)
+        profitable_position = create(:position, take_profit: 51_000.0, entry_price: 50_000.0)
+        allow(lifecycle).to receive(:close) { |p, reason:|
+          p.force_close!(51_000.0, reason)
+          success_result(close_price: 51_000.0)
+        }
+        described_class.perform_now(position_id: profitable_position.id, reason: "take_profit")
+        expect(profitable_position.reload.status).to eq("CLOSED")
       end
     end
   end
@@ -476,52 +304,33 @@ RSpec.describe PositionCloseJob, type: :job do
     context "with large position sizes" do
       it "handles large position closure" do
         large_position = create(:position, size: 100.0)
-        allow(positions_service).to receive(:close_position).and_return({
-          success: true,
-          pnl: 5000.0
-        })
-
-        described_class.perform_now(
-          position_id: large_position.id,
-          reason: "manual_close"
-        )
-
-        large_position.reload
-        expect(large_position.status).to eq("CLOSED")
+        allow(lifecycle).to receive(:close) { |p, reason:|
+          p.force_close!(50_001.0, reason)
+          success_result
+        }
+        described_class.perform_now(position_id: large_position.id, reason: "manual_close")
+        expect(large_position.reload.status).to eq("CLOSED")
       end
     end
 
     context "with precision edge cases" do
       it "handles fractional position sizes" do
         fractional_position = create(:position, size: 0.001)
-        allow(positions_service).to receive(:close_position).and_return({
-          success: true,
-          pnl: 0.5
-        })
-
-        described_class.perform_now(
-          position_id: fractional_position.id,
-          reason: "take_profit"
-        )
-
-        fractional_position.reload
-        expect(fractional_position.status).to eq("CLOSED")
+        allow(lifecycle).to receive(:close) { |p, reason:|
+          p.force_close!(50_001.0, reason)
+          success_result
+        }
+        described_class.perform_now(position_id: fractional_position.id, reason: "take_profit")
+        expect(fractional_position.reload.status).to eq("CLOSED")
       end
     end
 
     context "with concurrent closure attempts" do
       it "handles race conditions gracefully" do
         concurrent_position = create(:position)
-
-        # Simulate concurrent closure by having the position already closed
         concurrent_position.update!(status: "CLOSED", close_time: Time.current)
-
-        expect(positions_service).not_to receive(:close_position)
-
-        described_class.perform_now(
-          position_id: concurrent_position.id,
-          reason: "manual_close"
-        )
+        expect(lifecycle).not_to receive(:close)
+        described_class.perform_now(position_id: concurrent_position.id, reason: "manual_close")
       end
     end
   end

--- a/spec/services/contract_expiry_manager_spec.rb
+++ b/spec/services/contract_expiry_manager_spec.rb
@@ -5,11 +5,21 @@ require "rails_helper"
 RSpec.describe ContractExpiryManager, type: :service do
   let(:logger) { double("logger", info: nil, warn: nil, error: nil) }
   let(:positions_service) { double("positions_service") }
+  let(:lifecycle) { double("lifecycle") }
   let(:slack_service) { double("slack_service", alert: nil) }
   let(:expiry_manager) { described_class.new(logger: logger) }
 
+  def success_result
+    Trading::PositionLifecycle::Result.new(success: true, close_price: 50_000.0, reason: nil, fallback: false)
+  end
+
+  def failure_result
+    Trading::PositionLifecycle::Result.new(success: false, close_price: nil, reason: nil, fallback: false)
+  end
+
   before do
     allow(Trading::CoinbasePositions).to receive(:new).and_return(positions_service)
+    allow(Trading::PositionLifecycle).to receive(:new).and_return(lifecycle)
     stub_const("SlackNotificationService", slack_service)
     travel_to Date.new(2025, 8, 25) # Monday, August 25, 2025
   end
@@ -50,15 +60,15 @@ RSpec.describe ContractExpiryManager, type: :service do
 
     context "when positions close successfully" do
       before do
-        allow(positions_service).to receive(:close_position).and_return({"success" => true})
+        allow(lifecycle).to receive(:close) { |pos, reason:|
+          pos.force_close!(50_000.0, reason)
+          success_result
+        }
       end
 
       it "closes all expiring positions" do
         result = expiry_manager.close_expiring_positions(2)
-
         expect(result).to eq(2)
-        expect(positions_service).to have_received(:close_position).with(product_id: "BIT-27AUG25-CDE")
-        expect(positions_service).to have_received(:close_position).with(product_id: "BIT-26AUG25-CDE")
       end
 
       it "sends notification for successful closures" do
@@ -79,32 +89,26 @@ RSpec.describe ContractExpiryManager, type: :service do
       end
     end
 
-    context "when API closure fails but local closure succeeds" do
+    context "when lifecycle falls back to local closure" do
       before do
-        allow(positions_service).to receive(:close_position).and_raise(StandardError, "API error")
-        allow_any_instance_of(Position).to receive(:get_current_market_price).and_return(50000.0)
-        allow_any_instance_of(Position).to receive(:force_close!)
+        allow(lifecycle).to receive(:close) { |pos, reason:|
+          pos.force_close!(50_000.0, reason)
+          Trading::PositionLifecycle::Result.new(success: true, close_price: 50_000.0, reason: reason, fallback: true)
+        }
       end
 
-      it "falls back to local closure" do
+      it "still counts as closed" do
         result = expiry_manager.close_expiring_positions(2)
-
         expect(result).to eq(2)
-        # Since we're using allow_any_instance_of, we can't use have_received on specific instances
-        # Instead, we verify the result and that the method was called
       end
     end
 
-    context "when both API and local closure fail" do
+    context "when lifecycle fails (no price available)" do
       before do
-        allow(positions_service).to receive(:close_position).and_raise(StandardError, "API error")
-        allow_any_instance_of(Position).to receive(:get_current_market_price).and_return(nil)
+        allow(lifecycle).to receive(:close).and_return(failure_result)
       end
 
-      it "logs errors and returns 0" do
-        expect(logger).to receive(:error).with(/API closure failed/)
-        expect(logger).to receive(:error).with(/Cannot close position.*no current price/)
-
+      it "returns 0" do
         result = expiry_manager.close_expiring_positions(2)
         expect(result).to eq(0)
       end
@@ -121,14 +125,15 @@ RSpec.describe ContractExpiryManager, type: :service do
       let!(:expired_position) { create(:position, product_id: "BIT-24AUG25-CDE", status: "OPEN") }
 
       before do
-        allow(positions_service).to receive(:close_position).and_return({"success" => true})
+        allow(lifecycle).to receive(:close) { |pos, reason:|
+          pos.force_close!(50_000.0, reason)
+          success_result
+        }
       end
 
       it "closes expired positions" do
         result = expiry_manager.close_expired_positions
-
         expect(result).to eq(1)
-        expect(positions_service).to have_received(:close_position).with(product_id: "BIT-24AUG25-CDE")
       end
 
       it "sends emergency notification" do
@@ -189,7 +194,10 @@ RSpec.describe ContractExpiryManager, type: :service do
     let!(:expiring_position) { create(:position, product_id: "BIT-27AUG25-CDE", status: "OPEN", size: 10) }
 
     before do
-      allow(positions_service).to receive(:close_position).and_return({"success" => true})
+      allow(lifecycle).to receive(:close) { |pos, reason:|
+        pos.force_close!(50_000.0, reason)
+        success_result
+      }
     end
 
     it "monitors balance impact and sends notification" do
@@ -290,46 +298,19 @@ RSpec.describe ContractExpiryManager, type: :service do
     describe "#close_single_position" do
       let(:position) { create(:position, product_id: "BIT-25AUG25-CDE", status: "OPEN") }
 
-      context "when API closure succeeds" do
-        before do
-          allow(positions_service).to receive(:close_position).and_return({"success" => true})
-        end
+      context "when lifecycle succeeds" do
+        before { allow(lifecycle).to receive(:close).and_return(success_result) }
 
-        it "closes position via API and returns 1" do
-          result = expiry_manager.send(:close_single_position, position, "Test reason")
-
-          expect(result).to eq(1)
-          expect(positions_service).to have_received(:close_position).with(product_id: position.product_id)
+        it "returns 1" do
+          expect(expiry_manager.send(:close_single_position, position, "Test reason")).to eq(1)
         end
       end
 
-      context "when API closure fails" do
-        before do
-          allow(positions_service).to receive(:close_position).and_return({"success" => false})
-          allow(position).to receive(:get_current_market_price).and_return(50000.0)
-          allow(position).to receive(:force_close!)
-        end
+      context "when lifecycle fails" do
+        before { allow(lifecycle).to receive(:close).and_return(failure_result) }
 
-        it "falls back to local closure" do
-          result = expiry_manager.send(:close_single_position, position, "Test reason")
-
-          expect(result).to eq(1)
-          expect(position).to have_received(:force_close!).with(50000.0, "Test reason")
-        end
-      end
-
-      context "when both API and local closure fail" do
-        before do
-          allow(positions_service).to receive(:close_position).and_raise(StandardError, "API error")
-          allow(position).to receive(:get_current_market_price).and_return(nil)
-        end
-
-        it "returns 0 and logs error" do
-          expect(logger).to receive(:error).with(/API closure failed/)
-          expect(logger).to receive(:error).with(/Cannot close position.*no current price/)
-
-          result = expiry_manager.send(:close_single_position, position, "Test reason")
-          expect(result).to eq(0)
+        it "returns 0" do
+          expect(expiry_manager.send(:close_single_position, position, "Test reason")).to eq(0)
         end
       end
     end

--- a/spec/services/trading/position_lifecycle_spec.rb
+++ b/spec/services/trading/position_lifecycle_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Trading::PositionLifecycle do
+  subject(:lifecycle) { described_class.new(positions_service: positions_service, logger: logger) }
+
+  let(:positions_service) { instance_double(Trading::CoinbasePositions) }
+  let(:logger) { instance_double(ActiveSupport::Logger, info: nil, warn: nil, error: nil) }
+  let(:position) { create(:position, status: "OPEN", entry_price: 50_000.0) }
+
+  before do
+    allow(RecentMarketPrice).to receive(:for_product).with(position.product_id).and_return(51_000.0)
+  end
+
+  describe "#close" do
+    context "API success" do
+      before do
+        allow(positions_service).to receive(:close_position).and_return({"success" => true, "order_id" => "abc123"})
+      end
+
+      it "returns successful result" do
+        result = lifecycle.close(position, reason: "Day trading closure")
+        expect(result).to be_success
+      end
+
+      it "closes position locally" do
+        lifecycle.close(position, reason: "Day trading closure")
+        expect(position.reload.status).to eq("CLOSED")
+      end
+
+      it "sets close price on result" do
+        result = lifecycle.close(position, reason: "Day trading closure")
+        expect(result.close_price).to eq(51_000.0)
+      end
+
+      it "result not fallback" do
+        result = lifecycle.close(position, reason: "Day trading closure")
+        expect(result.fallback).to be false
+      end
+    end
+
+    context "API bad response" do
+      before do
+        allow(positions_service).to receive(:close_position).and_return({"error" => "insufficient funds"})
+      end
+
+      it "still succeeds via fallback" do
+        result = lifecycle.close(position, reason: "Day trading closure")
+        expect(result).to be_success
+      end
+
+      it "marks result as fallback" do
+        result = lifecycle.close(position, reason: "Day trading closure")
+        expect(result.fallback).to be true
+      end
+
+      it "closes position locally" do
+        lifecycle.close(position, reason: "Day trading closure")
+        expect(position.reload.status).to eq("CLOSED")
+      end
+    end
+
+    context "API raises exception" do
+      before do
+        allow(positions_service).to receive(:close_position).and_raise(StandardError, "network timeout")
+      end
+
+      it "still succeeds via fallback" do
+        result = lifecycle.close(position, reason: "Day trading closure")
+        expect(result).to be_success
+      end
+
+      it "marks result as fallback" do
+        result = lifecycle.close(position, reason: "Day trading closure")
+        expect(result.fallback).to be true
+      end
+
+      it "closes position locally" do
+        lifecycle.close(position, reason: "Day trading closure")
+        expect(position.reload.status).to eq("CLOSED")
+      end
+    end
+
+    context "no price from any source" do
+      before do
+        allow(RecentMarketPrice).to receive(:for_product).with(position.product_id).and_return(nil)
+        allow(position).to receive(:entry_price).and_return(nil)
+        allow(positions_service).to receive(:close_position).and_return({"success" => true})
+      end
+
+      it "returns failure result" do
+        result = lifecycle.close(position, reason: "Day trading closure")
+        expect(result).not_to be_success
+      end
+
+      it "does not close position" do
+        lifecycle.close(position, reason: "Day trading closure")
+        expect(position.reload.status).to eq("OPEN")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extracts shared `Trading::PositionLifecycle#close` service that owns the full close pipeline: price resolution → API close → local fallback → structured `Result`
- `DayTradingPositionManager`, `SwingPositionManager`, `ContractExpiryManager`, `PositionCloseJob` all delegate to it — duplicate close/fallback/error logic removed from each
- Leaves explicit extension point for `Order` record persistence per ADR 0001

## Test plan

- [x] 12 lifecycle specs: normal close, bad API response, API exception, no-price failure
- [x] Existing day/swing manager specs still green (52 total, 0 failures)